### PR TITLE
Feature: Add PROGRAM message specification

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-/aleph_message/tests/test_messages/
+/aleph_message/tests/test_messages/*

--- a/aleph_message/__init__.py
+++ b/aleph_message/__init__.py
@@ -1,1 +1,1 @@
-from .models import BaseMessage, MessagesResponse
+from .models import Message, MessagesResponse

--- a/aleph_message/models/abstract.py
+++ b/aleph_message/models/abstract.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Extra
+
+
+class HashableModel(BaseModel):
+    def __hash__(self):
+        return hash(self.__class__) + hash(tuple(self.__dict__.values()))
+
+
+class BaseContent(BaseModel):
+    "Base template for message content"
+    address: str
+    time: float
+
+    class Config:
+        extra = Extra.forbid

--- a/aleph_message/models/program.py
+++ b/aleph_message/models/program.py
@@ -1,0 +1,73 @@
+from enum import Enum
+from typing import Optional
+
+from pydantic import Field
+
+from .abstract import BaseContent, HashableModel
+
+
+class Encoding(str, Enum):
+    plain = "plain"
+    zip = "zip"
+
+
+class MachineType(str, Enum):
+    vm_function = "vm-function"
+
+
+class CodeContent(HashableModel):
+    encoding: Encoding
+    entrypoint: str
+    ref: str
+    use_latest: bool = False
+
+
+class DataContent(HashableModel):
+    encoding: Encoding
+    mount: str
+    ref: str
+    use_latest: bool = False
+
+
+class Export(HashableModel):
+    encoding: Encoding
+    mount: str
+
+
+class FunctionTriggers(HashableModel):
+    http: bool
+
+
+class FunctionEnvironment(HashableModel):
+    reproducible: bool = False
+    internet: bool = False
+    aleph_api: bool = False
+
+
+class MachineResources(HashableModel):
+    vcpus: int = 1
+    memory: int = 128
+    seconds: int = 1
+
+
+class FunctionRuntime(HashableModel):
+    ref: str
+    use_latest: bool = True
+    comment: str
+
+
+class ProgramContent(BaseContent):
+    type: MachineType = Field(description="Type of execution")
+    allow_amend: bool = Field(description="Allow amends to update this function")
+    code: CodeContent = Field(description="Code to execute")
+    data: Optional[DataContent] = Field(description="Data to use during computation")
+    export: Optional[Export] = Field(description="Data to export after computation")
+    on: FunctionTriggers = Field("Signals that trigger an execution")
+    environment: FunctionEnvironment = Field("Properties of the execution environment")
+    resources: MachineResources = Field("System resources required")
+    runtime: FunctionRuntime = Field(
+        "Execution runtime (rootfs with Python interpreter)"
+    )
+    replaces: Optional[str] = Field(
+        description="Previous version to replace. Must be signed by the same address"
+    )

--- a/aleph_message/tests/messages/machine.json
+++ b/aleph_message/tests/messages/machine.json
@@ -1,0 +1,64 @@
+{
+    "_id": {
+        "$oid": "6080402d7f44efefd611dc1e"
+    },
+    "chain": "ETH",
+    "item_hash": "7c75d2b14ffb79a3e59f8075a45e46968f6ae01307cede23366d09a4c645102b",
+    "sender": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+    "type": "PROGRAM",
+    "channel": "Fun-dApps",
+    "confirmed": true,
+    "content": {
+        "type": "vm-function",
+        "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "allow_amend": false,
+        "code": {
+            "encoding": "zip",
+            "entrypoint": "example_fastapi_2:app",
+            "ref": "7eb2eca2378ea8855336ed76c8b26219f1cb90234d04441de9cf8cb1c649d003",
+            "use_latest": false
+        },
+        "on": {
+            "http": true
+        },
+        "environment": {
+            "reproducible": true,
+            "internet": false,
+            "aleph_api": false
+        },
+        "resources": {
+            "vcpus": 1,
+            "memory": 128,
+            "seconds": 30
+        },
+        "runtime": {
+            "ref": "5f31b0706f59404fad3d0bff97ef89ddf24da4761608ea0646329362c662ba51",
+            "use_latest": false,
+            "comment": "Aleph Alpine Linux with Python 3.8"
+        },
+        "data": {
+            "encoding": "zip",
+            "mount": "/data",
+            "ref": "7eb2eca2378ea8855336ed76c8b26219f1cb90234d04441de9cf8cb1c649d003",
+            "use_latest": false
+        },
+        "export": {
+            "encoding": "zip",
+            "mount": "/data"
+        },
+        "replaces": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "time": 1619017773.8950517
+    },
+    "item_content": "{\"address\": \"0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba\", \"time\": 1619017773.8950517, \"type\": \"vm-function\", \"allow_amend\": false, \"code\": {\"encoding\": \"zip\", \"entrypoint\": \"example_fastapi_2:app\", \"ref\": \"7eb2eca2378ea8855336ed76c8b26219f1cb90234d04441de9cf8cb1c649d003\", \"use_latest\": false}, \"data\": {\"encoding\": \"zip\", \"mount\": \"/data\", \"ref\": \"7eb2eca2378ea8855336ed76c8b26219f1cb90234d04441de9cf8cb1c649d003\", \"use_latest\": false}, \"export\": {\"encoding\": \"zip\", \"mount\": \"/data\"}, \"on\": {\"http\": true}, \"environment\": {\"reproducible\": true, \"internet\": false, \"aleph_api\": false}, \"resources\": {\"vcpus\": 1, \"memory\": 128, \"seconds\": 30}, \"runtime\": {\"ref\": \"5f31b0706f59404fad3d0bff97ef89ddf24da4761608ea0646329362c662ba51\", \"use_latest\": false, \"comment\": \"Aleph Alpine Linux with Python 3.8\"}, \"replaces\": \"0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba\"}",
+    "item_type": "inline",
+    "signature": "0x372da8230552b8c3e65c05b31a0ff3a24666d66c575f8e11019f62579bf48c2b7fe2f0bbe907a2a5bf8050989cdaf8a59ff8a1cbcafcdef0656c54279b4aa0c71b",
+    "size": 749,
+    "time": 1619017773.8950577,
+    "confirmations": [
+        {
+            "chain": "ETH",
+            "height": 12284734,
+            "hash": "0x67f2f3cde5e94e70615c92629c70d22dc959a118f46e9411b29659c2fce87cdc"
+        }
+    ]
+}


### PR DESCRIPTION
This adds a new type of message to the Aleph specificiation: `PROGRAM`.
Aleph message types become therefore `POST`, `AGGREGATE`, `STORE` and `PROGRAM`.

A message of type program contains information about a program to be executed and it's execution environment.

The `type` field in the content of such message defines the kind of program and environment to use. At the moment, `vm-function` is the only type supported. It executes the program in a Virtual Machine in the spirit of a _cloud function_. The other fields of the content are specific to the type of message.

