### PR TITLE
Fix: Field `forgotten_by` was not supported by the Message models.

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -217,6 +217,8 @@ class BaseMessage(BaseModel):
     item_hash: str = Field(description="Hash of the content (sha256 by default)")
     content: BaseContent = Field(description="Content of the message, ready to be used")
 
+    forgotten_by: Optional[List[str]]
+
     @validator("item_content")
     def check_item_content(cls, v: Optional[str], values):
         item_type = values["item_type"]
@@ -288,6 +290,12 @@ class StoreMessage(BaseMessage):
 class ForgetMessage(BaseMessage):
     type: Literal[MessageType.forget]
     content: ForgetContent
+
+    @validator('forgotten_by')
+    def cannot_be_forgotten(cls, v: Optional[List[str]], values) -> Optional[List[str]]:
+        if v:
+            raise ValueError("This type of message may not be forgotten")
+        return v
 
 
 class ProgramMessage(BaseMessage):

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -125,6 +125,26 @@ def test_message_forget():
 
     assert hash(message.content)
 
+    # A FORGET message may not be forgotten:
+    message_raw["forgotten_by"] = ['abcde']
+    with pytest.raises(ValueError) as e:
+        ForgetMessage(**message_raw)
+    assert e.value.args[0][0].exc.args == ("This type of message may not be forgotten", )
+
+
+def test_message_forgotten_by():
+    path = os.path.abspath(os.path.join(__file__, "../messages/machine.json"))
+    with open(path) as fd:
+        message_raw = json.load(fd)
+    message_raw['item_hash'] = sha256(json.dumps(message_raw['content']).encode()).hexdigest()
+    message_raw['item_content'] = json.dumps(message_raw['content'])
+
+    # Test different values for field 'forgotten_by'
+    _ = ProgramMessage(**message_raw)
+    _ = ProgramMessage(**message_raw, forgotten_by=None)
+    _ = ProgramMessage(**message_raw, forgotten_by=['abcde'])
+    _ = ProgramMessage(**message_raw, forgotten_by=['abcde', 'fghij'])
+
 
 @pytest.mark.skipif(not isdir(MESSAGES_STORAGE_PATH), reason="No file on disk to test")
 def test_messages_from_disk():


### PR DESCRIPTION
Solution: Add optional field `forgotten_by`, but prevent it from having any value on FORGET messages using an extra validator.