### PR TITLE
Fix: resolve breaking changes for ItemHash

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -80,7 +80,9 @@ class ItemHash(str):
     item_type: ItemType
 
     # When overriding str, override __new__ instead of __init__.
-    def __new__(cls, value, item_type: ItemType):
+    def __new__(cls, value: str):
+        item_type = ItemType.from_hash(value)
+
         obj = str.__new__(cls, value)
         obj.item_type = item_type
         return obj
@@ -97,12 +99,7 @@ class ItemHash(str):
         if not isinstance(v, str):
             raise TypeError("Item hash must be a string")
 
-        try:
-            item_type = ItemType.from_hash(v)
-        except UnknownHashError as e:
-            raise ValueError(str(e))
-
-        return cls(v, item_type)
+        return cls(v)
 
     def __repr__(self):
         return f"<ItemHash value={super().__repr__()} item_type={self.item_type!r}>"

--- a/aleph_message/tests/test_types.py
+++ b/aleph_message/tests/test_types.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import ItemHash, ItemType
 
 STORAGE_HASH = "b236db23bf5ad005ad7f5d82eed08a68a925020f0755b2a59c03f784499198eb"
@@ -36,6 +37,14 @@ def test_item_hash():
         _ = ModelWithItemHash.parse_obj(invalid_object_dict)
 
 
+def test_item_hash_serialization():
+    ipfs_object = ModelWithItemHash(hash=STORAGE_HASH)
+    assert ipfs_object.json() == '{"hash": "b236db23bf5ad005ad7f5d82eed08a68a925020f0755b2a59c03f784499198eb"}'
+
+    ipfs_object = ModelWithItemHash(hash=IPFS_HASH)
+    assert ipfs_object.json() == '{"hash": "QmPxCe3eHVCdTG5uKnSZTsPGrYvMFTWAAt4PSfK7ETkz4d"}'
+
+
 def test_copy_item_hash():
     item_hash = ItemHash(STORAGE_HASH)
 
@@ -46,3 +55,11 @@ def test_copy_item_hash():
     item_hash_deepcopy = copy.deepcopy(item_hash)
     assert item_hash_deepcopy == item_hash
     assert item_hash_deepcopy.item_type == item_hash.item_type
+
+
+def test_bad_item_hashes():
+    with pytest.raises(UnknownHashError):
+        ItemHash("This is not a hash !")
+    # UnknownHashError should be a ValueError
+    with pytest.raises(ValueError):
+        ItemHash("This is not a hash !")

--- a/aleph_message/tests/test_types.py
+++ b/aleph_message/tests/test_types.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 from pydantic import BaseModel, ValidationError
 
@@ -32,3 +34,15 @@ def test_item_hash():
     invalid_object_dict = {"hash": "fake-hash"}
     with pytest.raises(ValidationError):
         _ = ModelWithItemHash.parse_obj(invalid_object_dict)
+
+
+def test_copy_item_hash():
+    item_hash = ItemHash(STORAGE_HASH)
+
+    item_hash_copy = copy.copy(item_hash)
+    assert item_hash_copy == item_hash
+    assert item_hash_copy.item_type == item_hash.item_type
+
+    item_hash_deepcopy = copy.deepcopy(item_hash)
+    assert item_hash_deepcopy == item_hash
+    assert item_hash_deepcopy.item_type == item_hash.item_type


### PR DESCRIPTION
Problems:
* Changes on ItemHash break using copy.copy(ItemHash(...)) (#22)
* Creating new ItemHash objects should not require passing an ItemType every time (#21)

Solution: compute the item type inside `__new__` instead of passing it as a parameter.

Resolves #20 and #21.