### PR TITLE
Fix: Any invalid message in a response crashed the entire response

### DIFF
--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -237,3 +237,16 @@ def test_messages_from_disk():
                 console.print(message_dict)
                 console.print_json(e.json())
                 raise
+
+
+def test_invalid_messages():
+    """Invalid messages should not crash the entire generation of the MessagesResponse object."""
+    path = Path(
+        os.path.abspath(
+            os.path.join(__file__, "../messages/contains_invalid_messages.json")
+        )
+    )
+    with open(path) as fd:
+        response_dict = json.load(fd)
+
+    MessagesResponse(**response_dict)


### PR DESCRIPTION
The code serving the API may return messages that are not valid according the latest version of the schemas. Ignore them with a warning instead of failing the parsing of the entire response.

Closes https://github.com/aleph-im/aleph-client/issues/108