### PR TITLE
Feature: support confirmation time and publisher fields

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -147,7 +147,7 @@ class MessageConfirmation(BaseModel):
     # These two optional fields are introduced in recent versions of CCNs. They should
     # remain optional until the corresponding CCN upload (0.4.0) is widely uploaded.
     time: Optional[float] = None
-    publisher: Optional[str] = None
+    publisher: Optional[str] = Field(default=None, description="The address that published the transaction.")
 
     class Config:
         extra = Extra.forbid


### PR DESCRIPTION
Problem: CCNs will add two new fields to the confirmations array of messages.

Solution: support these new fields and make them optional for backward compatibility.