### PR TITLE
Fix: restrict aggregate content to dictionaries

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -190,9 +190,7 @@ class AggregateContent(BaseContent):
     key: Union[str, AggregateContentKey] = Field(
         description="The aggregate key can be either a string of a dict containing the key in field 'name'"
     )
-    content: Union[Dict, List, str, int, float, bool, None] = Field(
-        description="The content of an aggregate must be a dict"
-    )
+    content: Dict = Field(description="The content of an aggregate must be a dict")
 
     class Config:
         extra = Extra.forbid


### PR DESCRIPTION
Problem: aggregates implement a key/value store, storing anything besides dictionaries makes no sense.

Solution: only accept dictionaries.