### PR TITLE
Fix: restrict program refs to item hashes

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -1,11 +1,12 @@
 import json
 from copy import copy
 from enum import Enum
-from functools import lru_cache
 from hashlib import sha256
 from json import JSONDecodeError
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Union, NewType
+
+from .item_hash import ItemHash, ItemType
 
 try:
     from typing import Literal
@@ -16,7 +17,6 @@ from pydantic import BaseModel, Extra, Field, validator
 
 from .abstract import BaseContent
 from .program import ProgramContent
-from ..exceptions import UnknownHashError
 
 
 class Chain(str, Enum):
@@ -47,64 +47,6 @@ class MessageType(str, Enum):
     store = "STORE"
     program = "PROGRAM"
     forget = "FORGET"
-
-
-class ItemType(str, Enum):
-    """Item storage options"""
-
-    inline = "inline"
-    storage = "storage"
-    ipfs = "ipfs"
-
-    @classmethod
-    @lru_cache
-    def from_hash(cls, item_hash: str) -> "ItemType":
-        # https://docs.ipfs.io/concepts/content-addressing/#identifier-formats
-        if item_hash.startswith("Qm") and 44 <= len(item_hash) <= 46:  # CIDv0
-            return cls.ipfs
-        elif item_hash.startswith("bafy") and len(item_hash) == 59:  # CIDv1
-            return cls.ipfs
-        elif len(item_hash) == 64:
-            return cls.storage
-        else:
-            raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
-
-    @classmethod
-    def is_storage(cls, item_hash: str):
-        return cls.from_hash(item_hash) == cls.storage
-
-    @classmethod
-    def is_ipfs(cls, item_hash: str):
-        return cls.from_hash(item_hash) == cls.ipfs
-
-
-class ItemHash(str):
-    item_type: ItemType
-
-    # When overriding str, override __new__ instead of __init__.
-    def __new__(cls, value: str):
-        item_type = ItemType.from_hash(value)
-
-        obj = str.__new__(cls, value)
-        obj.item_type = item_type
-        return obj
-
-    @classmethod
-    def __get_validators__(cls):
-        # one or more validators may be yielded which will be called in the
-        # order to validate the input, each validator will receive as an input
-        # the value returned from the previous validator
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, v):
-        if not isinstance(v, str):
-            raise TypeError("Item hash must be a string")
-
-        return cls(v)
-
-    def __repr__(self):
-        return f"<ItemHash value={super().__repr__()} item_type={self.item_type!r}>"
 
 
 class MongodbId(BaseModel):

--- a/aleph_message/models/item_hash.py
+++ b/aleph_message/models/item_hash.py
@@ -1,0 +1,67 @@
+from enum import Enum
+from functools import lru_cache
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
+from ..exceptions import UnknownHashError
+
+
+class ItemType(str, Enum):
+    """Item storage options"""
+
+    inline = "inline"
+    storage = "storage"
+    ipfs = "ipfs"
+
+    @classmethod
+    @lru_cache
+    def from_hash(cls, item_hash: str) -> "ItemType":
+        # https://docs.ipfs.io/concepts/content-addressing/#identifier-formats
+        if item_hash.startswith("Qm") and 44 <= len(item_hash) <= 46:  # CIDv0
+            return cls.ipfs
+        elif item_hash.startswith("bafy") and len(item_hash) == 59:  # CIDv1
+            return cls.ipfs
+        elif len(item_hash) == 64:
+            return cls.storage
+        else:
+            raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
+
+    @classmethod
+    def is_storage(cls, item_hash: str):
+        return cls.from_hash(item_hash) == cls.storage
+
+    @classmethod
+    def is_ipfs(cls, item_hash: str):
+        return cls.from_hash(item_hash) == cls.ipfs
+
+
+class ItemHash(str):
+    item_type: ItemType
+
+    # When overriding str, override __new__ instead of __init__.
+    def __new__(cls, value: str):
+        item_type = ItemType.from_hash(value)
+
+        obj = str.__new__(cls, value)
+        obj.item_type = item_type
+        return obj
+
+    @classmethod
+    def __get_validators__(cls):
+        # one or more validators may be yielded which will be called in the
+        # order to validate the input, each validator will receive as an input
+        # the value returned from the previous validator
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not isinstance(v, str):
+            raise TypeError("Item hash must be a string")
+
+        return cls(v)
+
+    def __repr__(self):
+        return f"<ItemHash value={super().__repr__()} item_type={self.item_type!r}>"

--- a/aleph_message/models/program.py
+++ b/aleph_message/models/program.py
@@ -8,6 +8,7 @@ from pydantic import Field, Extra, conint
 from typing_extensions import Literal
 
 from .abstract import BaseContent, HashableModel
+from .item_hash import ItemHash
 
 Megabytes = NewType("Megabytes", int)
 
@@ -25,14 +26,14 @@ class MachineType(str, Enum):
 class CodeContent(HashableModel):
     encoding: Encoding
     entrypoint: str
-    ref: str
+    ref: ItemHash
     use_latest: bool = False
 
 
 class DataContent(HashableModel):
     encoding: Encoding
     mount: str
-    ref: str
+    ref: ItemHash
     use_latest: bool = False
 
 
@@ -74,9 +75,9 @@ class CpuProperties(HashableModel):
     architecture: Optional[Literal["x86_64", "arm64"]] = Field(
         default=None, description="CPU architecture"
     )
-    vendor: Optional[
-        Union[Literal["AuthenticAMD", "GenuineIntel"], str]
-    ] = Field(default=None, description="CPU vendor. Allows other vendors.")
+    vendor: Optional[Union[Literal["AuthenticAMD", "GenuineIntel"], str]] = Field(
+        default=None, description="CPU vendor. Allows other vendors."
+    )
 
     class Config:
         extra = Extra.forbid
@@ -106,7 +107,7 @@ class HostRequirements(HashableModel):
 
 
 class FunctionRuntime(HashableModel):
-    ref: str
+    ref: ItemHash
     use_latest: bool = True
     comment: str
 
@@ -124,7 +125,7 @@ class AbstractVolume(HashableModel, ABC):
 
 
 class ImmutableVolume(AbstractVolume):
-    ref: str
+    ref: ItemHash
     use_latest: bool = True
 
     def is_read_only(self):


### PR DESCRIPTION
Problem: some users specify nonsensical strings in the ref field of programs and program volumes.

Solution: enforce the use of item hashes with the `ItemHash` type.

Moved the `ItemHash` and `ItemType` definitions to their own module to avoid circular imports.