### PR TITLE
Fix: allow None in message signature field

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -186,7 +186,7 @@ class BaseMessage(BaseModel):
         default=None,
         description="Indicates that the message has been confirmed on a blockchain",
     )
-    signature: str = Field(
+    signature: Optional[str] = Field(
         description="Cryptographic signature of the message by the sender"
     )
     size: Optional[int] = Field(


### PR DESCRIPTION
Problem: Aleph messages coming from smart contracts do not have a signature.

Solution: allow None in the message signature field.