### PR TITLE
Fix: Message status had no model representation.

### DIFF
--- a/aleph_message/status.py
+++ b/aleph_message/status.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+
+class MessageStatus(str, Enum):
+    """The current of the processing of a message by a node.
+
+    pending: the message is waiting to be processed.
+    processed: the message has been processed successfully.
+    rejected: the message is invalid and has been rejected.
+    forgotten: a FORGET message required this message content to be deleted.
+    """
+
+    PENDING = "pending"
+    PROCESSED = "processed"
+    REJECTED = "rejected"
+    FORGOTTEN = "forgotten"


### PR DESCRIPTION
The message status is used by APIs to represent the status of the processing of a message by a node.
