### PR TITLE
Feature: Handle forgotten messages

### DIFF
--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -209,6 +209,7 @@ def test_message_machine_named():
 
     message = create_message_from_file(path, factory=ProgramMessage)
     assert isinstance(message, ProgramMessage)
+    assert message.content
     assert isinstance(message.content.metadata, dict)
     assert message.content.metadata["version"] == "10.2"
 


### PR DESCRIPTION
This adds a type, `ForgottenMessage`, capable of handling messages with an empty content (since it has been deleted). Note that a message can be mapped to both a normal message and a `ForgottenMessage`.