### PR TITLE
Fix: use a dedicated model for instance rootfs

### DIFF
--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -1,18 +1,35 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Literal
+from typing import Any, Dict
 
 from pydantic import Field
 
+from aleph_message.models.abstract import HashableModel
+from aleph_message.models.item_hash import ItemHash
 from .abstract import BaseExecutableContent
-from .base import MachineType
-from .volume import PersistentVolume
+from .volume import VolumePersistence, PersistentVolumeSizeMib
+
+
+class RootfsVolume(HashableModel):
+    """
+    Root file system of a VM instance.
+
+    The root file system of an instance is built as a copy of a reference image, named parent
+    image. The user determines a custom size and persistence model.
+    """
+    parent: ItemHash
+    persistence: VolumePersistence
+    # Use the same size constraint as persistent volumes for now
+    size_mib: PersistentVolumeSizeMib
+    # Whether the volume must be based on the latest version of the parent volume or
+    # on the original. We use the original by default for consistency with programs.
+    use_latest: bool = False
 
 
 class InstanceContent(BaseExecutableContent):
     """Message content for scheduling a VM instance on the network."""
 
-    rootfs: PersistentVolume = Field(
+    rootfs: RootfsVolume = Field(
         description="Root filesystem of the system, will be booted by the kernel"
     )
     cloud_config: Dict[str, Any] = Field(

--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from aleph_message.models.abstract import HashableModel
 from aleph_message.models.item_hash import ItemHash
 from .abstract import BaseExecutableContent
-from .volume import VolumePersistence, PersistentVolumeSizeMib
+from .volume import VolumePersistence, PersistentVolumeSizeMib, ParentVolume
 
 
 class RootfsVolume(HashableModel):
@@ -17,13 +17,10 @@ class RootfsVolume(HashableModel):
     The root file system of an instance is built as a copy of a reference image, named parent
     image. The user determines a custom size and persistence model.
     """
-    parent: ItemHash
+    parent: ParentVolume
     persistence: VolumePersistence
     # Use the same size constraint as persistent volumes for now
     size_mib: PersistentVolumeSizeMib
-    # Whether the volume must be based on the latest version of the parent volume or
-    # on the original. We use the original by default for consistency with programs.
-    use_latest: bool = False
 
 
 class InstanceContent(BaseExecutableContent):

--- a/aleph_message/models/execution/volume.py
+++ b/aleph_message/models/execution/volume.py
@@ -51,7 +51,7 @@ class ParentVolume(HashableModel):
     """
 
     ref: ItemHash
-    use_latest: bool = False
+    use_latest: bool = True
 
 
 class VolumePersistence(str, Enum):

--- a/aleph_message/tests/messages/instance_machine.json
+++ b/aleph_message/tests/messages/instance_machine.json
@@ -36,8 +36,7 @@
               "use_latest": true
             },
             "persistence": "host",
-            "size_mib": 20000,
-            "use_latest": true
+            "size_mib": 20000
         },
         "cloud_config": {
             "password": "password"

--- a/aleph_message/tests/messages/instance_machine.json
+++ b/aleph_message/tests/messages/instance_machine.json
@@ -36,8 +36,8 @@
               "use_latest": true
             },
             "persistence": "host",
-            "name": "test-rootfs",
-            "size_mib": 20000
+            "size_mib": 20000,
+            "use_latest": true
         },
         "cloud_config": {
             "password": "password"


### PR DESCRIPTION
Problem: re-using the persistent volume model is not a perfect fit when implementing the logic to support instances in the rest of the aleph.im stack. Ex: the `mount` point does not make sense (it will always be `/`), neither do the `comment` or `name` fields. Similarly, the `parent` field must always be specified for root file systems.

Solution: use a custom model to refine the fields required.