### PR TITLE
Fix: lib was not compatible with newer versions of Pydantic

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -75,7 +75,7 @@ class ChainRef(BaseModel):
     sender: str
     signature: str
     time: float
-    type = "POST"
+    type: Literal["POST"] = "POST"
 
 
 class MessageConfirmationHash(BaseModel):


### PR DESCRIPTION
Problem: Non-annotated class attributes are no longer supported by Pydantic.

Solution: add an annotation.