### PR TITLE
Fix: CI was broken because of the release of Pydantic 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9-bullseye
 
 COPY aleph_message /opt/aleph_message
-RUN pip install .[testing]
+RUN pip install /opt/aleph-message[testing]
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9-bullseye
 
-COPY aleph_message /opt/aleph_message
-RUN cd /opt/aleph_message && pip install .[testing]
+COPY . /opt/aleph-message
+RUN cd /opt/aleph-message && pip install -e .[testing]
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-bullseye
 
-RUN pip install pytest pytest-cov mypy twine typing-extensions
+RUN pip install pytest requests types-requests pytest-cov mypy twine typing-extensions
 COPY . /opt/aleph-message
 WORKDIR /opt/aleph-message
 RUN pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9-bullseye
 
 COPY aleph_message /opt/aleph_message
-RUN pip install /opt/aleph-message[testing]
+RUN cd /opt/aleph-message && pip install .[testing]
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9-bullseye
 
 COPY aleph_message /opt/aleph_message
-RUN cd /opt/aleph-message && pip install .[testing]
+RUN cd /opt/aleph_message && pip install .[testing]
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.9-bullseye
 
-RUN pip install pydantic pytest pytest-cov mypy requests twine typing-extensions types-requests
-
 COPY aleph_message /opt/aleph_message
+RUN pip install .[testing]
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.9-bullseye
 
+RUN pip install pytest pytest-cov mypy twine typing-extensions
 COPY . /opt/aleph-message
-RUN cd /opt/aleph-message && pip install -e .[testing]
-WORKDIR /opt
+WORKDIR /opt/aleph-message
+RUN pip install -e .


### PR DESCRIPTION
Problem: some parts of the codebase are incompatible with Pydantic 2.0. We do not fix the version of Pydantic (and other dependencies) in the CI.

Solution: pip install the package directly in the CI Dockerfile.