### PR TITLE
Extend entrypoint parameter

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -351,13 +351,22 @@ def parse_message(message_dict: Dict) -> AlephMessage:
         raise ValueError(f"Unknown message type {message_dict['type']}")
 
 
-def add_item_content_and_hash(message_dict: Dict, inplace: bool = False):
+def add_item_content_and_hash(
+    message_dict: Dict,
+    inplace: bool = False,
+    factory: Optional[AlephContentType] = None,
+) -> Dict:
     if not inplace:
         message_dict = copy(message_dict)
-
-    message_dict["item_content"] = json.dumps(
-        message_dict["content"], separators=(",", ":")
-    )
+    if factory:
+        content = factory.parse_obj(message_dict["content"])
+        message_dict["item_content"] = json.dumps(
+            content.dict(exclude_none=True), separators=(",", ":")
+        )
+    else:
+        message_dict["item_content"] = json.dumps(
+            message_dict["content"], separators=(",", ":")
+        )
     message_dict["item_hash"] = sha256(
         message_dict["item_content"].encode()
     ).hexdigest()

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -4,15 +4,7 @@ from copy import copy
 from hashlib import sha256
 from json import JSONDecodeError
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Type,
-    Union, TypeVar, cast,
-)
+from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union, cast
 
 from pydantic import BaseModel, Extra, Field, validator
 from typing_extensions import TypeAlias
@@ -174,7 +166,9 @@ class BaseMessage(BaseModel):
     size: Optional[int] = Field(
         default=None, description="Size of the content"
     )  # Almost always present
-    time: datetime.datetime = Field(description="Unix timestamp or datetime when the message was published")
+    time: datetime.datetime = Field(
+        description="Unix timestamp or datetime when the message was published"
+    )
     item_type: ItemType = Field(description="Storage method used for the content")
     item_content: Optional[str] = Field(
         default=None,
@@ -319,7 +313,7 @@ AlephMessage: TypeAlias = Union[
 ]
 
 
-T = TypeVar('T', bound=AlephMessage)
+T = TypeVar("T", bound=AlephMessage)
 
 AlephMessageType: TypeAlias = Type[T]
 

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -284,7 +284,7 @@ class ProgramMessage(BaseMessage):
     content: ProgramContent
 
     @classmethod
-    def parse_obj(cls, obj: Dict) -> "AlephContentType":
+    def parse_obj(cls, obj: Dict) -> "ProgramMessage":
         obj = add_item_content_and_hash(obj, factory=ProgramContent)
 
         return super().parse_obj(obj)

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -283,6 +283,12 @@ class ProgramMessage(BaseMessage):
     type: Literal[MessageType.program]
     content: ProgramContent
 
+    @classmethod
+    def parse_obj(cls, obj: Dict) -> "AlephContentType":
+        obj = add_item_content_and_hash(obj, factory=ProgramContent)
+
+        return super().parse_obj(obj)
+
     @validator("content")
     def check_content(cls, v, values):
         item_type = values["item_type"]
@@ -324,6 +330,15 @@ message_classes: List[AlephMessageType] = [
     ProgramMessage,
     InstanceMessage,
     ForgetMessage,
+]
+
+AlephContentType: TypeAlias = Union[
+    Type[PostContent],
+    Type[AggregateContent],
+    Type[StoreContent],
+    Type[ProgramContent],
+    Type[InstanceContent],
+    Type[ForgetContent],
 ]
 
 ExecutableContent: TypeAlias = Union[InstanceContent, ProgramContent]

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -183,7 +183,7 @@ class BaseMessage(BaseModel):
     forgotten_by: Optional[List[str]]
 
     @validator("item_content")
-    def check_item_content(cls, v: Optional[str], values):
+    def check_item_content(cls, v: Optional[str], values) -> Optional[str]:
         item_type = values["item_type"]
         if v is None:
             return None
@@ -201,7 +201,7 @@ class BaseMessage(BaseModel):
         return v
 
     @validator("item_hash")
-    def check_item_hash(cls, v, values):
+    def check_item_hash(cls, v: ItemHash, values) -> ItemHash:
         item_type = values["item_type"]
         if item_type == ItemType.inline:
             item_content: str = values["item_content"]

--- a/aleph_message/models/execution/base.py
+++ b/aleph_message/models/execution/base.py
@@ -43,3 +43,11 @@ class Payment(HashableModel):
     @property
     def is_stream(self):
         return self.type == PaymentType.superfluid
+
+
+class Interface(str, Enum):
+    """Two types of program interfaces supported:
+    Running plain binary and ASGI apps."""
+
+    asgi = "asgi"
+    binary = "binary"

--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
 from pydantic import Field
 
 from aleph_message.models.abstract import HashableModel
-from aleph_message.models.item_hash import ItemHash
+
 from .abstract import BaseExecutableContent
-from .volume import VolumePersistence, PersistentVolumeSizeMib, ParentVolume
+from .volume import ParentVolume, PersistentVolumeSizeMib, VolumePersistence
 
 
 class RootfsVolume(HashableModel):
@@ -17,6 +15,7 @@ class RootfsVolume(HashableModel):
     The root file system of an instance is built as a copy of a reference image, named parent
     image. The user determines a custom size and persistence model.
     """
+
     parent: ParentVolume
     persistence: VolumePersistence
     # Use the same size constraint as persistent volumes for now
@@ -29,4 +28,3 @@ class InstanceContent(BaseExecutableContent):
     rootfs: RootfsVolume = Field(
         description="Root filesystem of the system, will be booted by the kernel"
     )
-

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -17,11 +17,25 @@ class FunctionRuntime(HashableModel):
     comment: str
 
 
+class Entrypoint(HashableModel):
+    """
+    Entrypoint to a program.
+
+    The type of the entrypoint determines how the program is executed.
+    The name of the entrypoint determines which file or function is executed.
+    Additional arguments can be provided.
+    """
+
+    name: str
+    type: Literal["python-asgi"] | Literal["bash"] | Literal["binary"] | Literal["node.js"]
+    args: list[str]
+
+
 class CodeContent(HashableModel):
     """Reference to the StoreMessage that contains the code or program to be executed."""
 
     encoding: Encoding
-    entrypoint: str
+    entrypoint: Entrypoint
     ref: ItemHash  # Must reference a StoreMessage
     use_latest: bool = False
 

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -4,11 +4,11 @@ from typing import Literal, Optional, Union
 
 from pydantic import Field
 
-from .environment import FunctionTriggers
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
 from .abstract import BaseExecutableContent
 from .base import Encoding, MachineType
+from .environment import FunctionTriggers
 
 
 class FunctionRuntime(HashableModel):
@@ -22,8 +22,10 @@ class CodeContent(HashableModel):
 
     encoding: Encoding
     entrypoint: str
-    interface: Union[Literal["asgi"], Literal["bash"], Literal["binary"], Literal["npm"]]
     ref: ItemHash  # Must reference a StoreMessage
+    interface: Union[
+        Literal["asgi"], Literal["bash"], Literal["binary"], Literal["npm"]
+    ] = Field(default="asgi")
     args: list[str] = Field(default_factory=list)
     use_latest: bool = False
 

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import Literal, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, validator
 
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
 from .abstract import BaseExecutableContent
-from .base import Encoding, MachineType
+from .base import Encoding, Interface, MachineType
 from .environment import FunctionTriggers
 
 
@@ -23,11 +23,19 @@ class CodeContent(HashableModel):
     encoding: Encoding
     entrypoint: str
     ref: ItemHash  # Must reference a StoreMessage
-    interface: Union[
-        Literal["asgi"], Literal["bash"], Literal["binary"], Literal["npm"]
-    ] = Field(default="asgi")
-    args: list[str] = Field(default_factory=list)
+    interface: Optional[Interface] = None
+    args: Optional[list[str]] = None
     use_latest: bool = False
+
+    @property
+    def inferred_interface(self) -> Interface:
+        """The initial behaviour is to use asgi, if there is a semicolon in the entrypoint. Else, assume its a binary on port 8000."""
+        if self.interface:
+            return self.interface
+        elif ":" in self.entrypoint:
+            return Interface.asgi
+        else:
+            return Interface.binary
 
 
 class DataContent(HashableModel):

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -35,7 +35,7 @@ class CodeContent(HashableModel):
     """Reference to the StoreMessage that contains the code or program to be executed."""
 
     encoding: Encoding
-    entrypoint: Entrypoint
+    entrypoint: Entrypoint | str
     ref: ItemHash  # Must reference a StoreMessage
     use_latest: bool = False
 

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 from pydantic import Field
 
@@ -27,7 +27,7 @@ class Entrypoint(HashableModel):
     """
 
     name: str
-    type: Literal["python-asgi"] | Literal["bash"] | Literal["binary"] | Literal["node.js"]
+    type: Union[Literal["python-asgi"], Literal["bash"], Literal["binary"], Literal["node.js"]]
     args: list[str]
 
 
@@ -35,7 +35,7 @@ class CodeContent(HashableModel):
     """Reference to the StoreMessage that contains the code or program to be executed."""
 
     encoding: Encoding
-    entrypoint: Entrypoint | str
+    entrypoint: Union[Entrypoint, str]
     ref: ItemHash  # Must reference a StoreMessage
     use_latest: bool = False
 

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -17,26 +17,14 @@ class FunctionRuntime(HashableModel):
     comment: str
 
 
-class Entrypoint(HashableModel):
-    """
-    Entrypoint to a program.
-
-    The type of the entrypoint determines how the program is executed.
-    The name of the entrypoint determines which file or function is executed.
-    Additional arguments can be provided.
-    """
-
-    name: str
-    type: Union[Literal["python-asgi"], Literal["bash"], Literal["binary"], Literal["node.js"]]
-    args: list[str]
-
-
 class CodeContent(HashableModel):
     """Reference to the StoreMessage that contains the code or program to be executed."""
 
     encoding: Encoding
-    entrypoint: Union[Entrypoint, str]
+    entrypoint: str
+    interface: Union[Literal["asgi"], Literal["bash"], Literal["binary"], Literal["npm"]]
     ref: ItemHash  # Must reference a StoreMessage
+    args: list[str] = Field(default_factory=list)
     use_latest: bool = False
 
 

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -13,7 +13,6 @@ from rich.console import Console
 from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import (
     AggregateMessage,
-    AlephMessage,
     ForgetMessage,
     InstanceMessage,
     ItemType,
@@ -238,7 +237,7 @@ def test_message_forgotten_by():
     path = os.path.abspath(os.path.join(__file__, "../messages/machine.json"))
     with open(path) as fd:
         message_raw = json.load(fd)
-    message_raw = add_item_content_and_hash(message_raw, factory=ProgramContent)
+    message_raw = add_item_content_and_hash(message_raw)
 
     # Test different values for field 'forgotten_by'
     _ = ProgramMessage.parse_obj(message_raw)

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -89,7 +89,7 @@ def test_messages_last_page():
         if message_dict["item_hash"] in HASHES_TO_IGNORE:
             continue
 
-        message: AlephMessage = parse_message(message_dict)
+        message = parse_message(message_dict)
         assert message
 
 
@@ -287,7 +287,7 @@ def test_create_new_message():
         "signature": "0x123456789",  # Signature validation requires using aleph-client
     }
 
-    new_message_1: PostMessage = create_new_message(message_dict, factory=PostMessage)
+    new_message_1 = create_new_message(message_dict, factory=PostMessage)
     assert new_message_1
     assert new_message_1.type == MessageType.post
     # Check that the time was converted to a datetime
@@ -310,7 +310,7 @@ def test_messages_from_disk():
             data_dict = json.load(page_fd)
         for message_dict in data_dict["messages"]:
             try:
-                message: AlephMessage = parse_message(message_dict)
+                message = parse_message(message_dict)
                 assert message
             except ValidationError as e:
                 console.print("-" * 79)

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from aleph_message.exceptions import UnknownHashError
 from aleph_message.models import (
     AggregateMessage,
+    AlephMessage,
     ForgetMessage,
     InstanceMessage,
     ItemType,
@@ -26,7 +27,7 @@ from aleph_message.models import (
     create_message_from_file,
     create_message_from_json,
     create_new_message,
-    parse_message, AlephMessage,
+    parse_message,
 )
 from aleph_message.tests.download_messages import MESSAGES_STORAGE_PATH
 
@@ -290,10 +291,10 @@ def test_create_new_message():
     assert new_message_1
     assert new_message_1.type == MessageType.post
     # Check that the time was converted to a datetime
-    assert new_message_1.time.isoformat() == '2021-07-07T10:04:47.017000+00:00'
+    assert new_message_1.time.isoformat() == "2021-07-07T10:04:47.017000+00:00"
 
     # The time field can be either a float or a datetime as string
-    message_dict["time"] = '2021-07-07T10:04:47.017000+00:00'
+    message_dict["time"] = "2021-07-07T10:04:47.017000+00:00"
     new_message_2 = create_message_from_json(
         json.dumps(message_dict), factory=PostMessage
     )

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -20,6 +20,7 @@ from aleph_message.models import (
     MessageType,
     PostContent,
     PostMessage,
+    ProgramContent,
     ProgramMessage,
     add_item_content_and_hash,
     create_message_from_file,
@@ -236,7 +237,7 @@ def test_message_forgotten_by():
     path = os.path.abspath(os.path.join(__file__, "../messages/machine.json"))
     with open(path) as fd:
         message_raw = json.load(fd)
-    message_raw = add_item_content_and_hash(message_raw)
+    message_raw = add_item_content_and_hash(message_raw, factory=ProgramContent)
 
     # Test different values for field 'forgotten_by'
     _ = ProgramMessage.parse_obj(message_raw)


### PR DESCRIPTION
In reference to https://github.com/aleph-im/aleph-vm/issues/482.

Allows distinction between different types of plain code executions and more freedom in defining how it should be run.