### PR TITLE
Add `payment` field to `BaseExecutableContent` with specifics for payment type

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -21,6 +21,7 @@ from .abstract import BaseContent
 from .base import Chain, HashType, MessageType
 from .execution.instance import InstanceContent
 from .execution.program import ProgramContent
+from .execution.base import PaymentType, MachineType, Payment
 from .item_hash import ItemHash, ItemType
 
 

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -4,7 +4,15 @@ from copy import copy
 from hashlib import sha256
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union, cast
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Type,
+    Union, TypeVar, cast,
+)
 
 from pydantic import BaseModel, Extra, Field, validator
 from typing_extensions import TypeAlias
@@ -165,9 +173,7 @@ class BaseMessage(BaseModel):
     size: Optional[int] = Field(
         default=None, description="Size of the content"
     )  # Almost always present
-    time: datetime.datetime = Field(
-        description="Unix timestamp or datetime when the message was published"
-    )
+    time: datetime.datetime = Field(description="Unix timestamp or datetime when the message was published")
     item_type: ItemType = Field(description="Storage method used for the content")
     item_content: Optional[str] = Field(
         default=None,
@@ -306,7 +312,7 @@ AlephMessage: TypeAlias = Union[
 ]
 
 
-T = TypeVar("T", bound=AlephMessage)
+T = TypeVar('T', bound=AlephMessage)
 
 AlephMessageType: TypeAlias = Type[T]
 

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -1,59 +1,19 @@
 import datetime
 import json
 from copy import copy
-from enum import Enum
 from hashlib import sha256
 from json import JSONDecodeError
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Type,
-    Union, TypeVar, cast,
-)
+from typing import Any, Dict, List, Literal, Optional, Type, TypeVar, Union, cast
 
 from pydantic import BaseModel, Extra, Field, validator
 from typing_extensions import TypeAlias
 
 from .abstract import BaseContent
+from .base import Chain, HashType, MessageType
 from .execution.instance import InstanceContent
 from .execution.program import ProgramContent
 from .item_hash import ItemHash, ItemType
-
-
-class Chain(str, Enum):
-    """Supported chains"""
-
-    AVAX = "AVAX"
-    BSC = "BSC"
-    CSDK = "CSDK"
-    DOT = "DOT"
-    ETH = "ETH"
-    NEO = "NEO"
-    NULS = "NULS"
-    NULS2 = "NULS2"
-    SOL = "SOL"
-    TEZOS = "TEZOS"
-
-
-class HashType(str, Enum):
-    """Supported hash functions"""
-
-    sha256 = "sha256"
-
-
-class MessageType(str, Enum):
-    """Message types supported by Aleph"""
-
-    post = "POST"
-    aggregate = "AGGREGATE"
-    store = "STORE"
-    program = "PROGRAM"
-    instance = "INSTANCE"
-    forget = "FORGET"
 
 
 class MongodbId(BaseModel):
@@ -205,7 +165,9 @@ class BaseMessage(BaseModel):
     size: Optional[int] = Field(
         default=None, description="Size of the content"
     )  # Almost always present
-    time: datetime.datetime = Field(description="Unix timestamp or datetime when the message was published")
+    time: datetime.datetime = Field(
+        description="Unix timestamp or datetime when the message was published"
+    )
     item_type: ItemType = Field(description="Storage method used for the content")
     item_content: Optional[str] = Field(
         default=None,
@@ -344,7 +306,7 @@ AlephMessage: TypeAlias = Union[
 ]
 
 
-T = TypeVar('T', bound=AlephMessage)
+T = TypeVar("T", bound=AlephMessage)
 
 AlephMessageType: TypeAlias = Type[T]
 

--- a/aleph_message/models/base.py
+++ b/aleph_message/models/base.py
@@ -1,0 +1,33 @@
+from enum import Enum
+
+
+class Chain(str, Enum):
+    """Supported chains"""
+
+    AVAX = "AVAX"
+    BSC = "BSC"
+    CSDK = "CSDK"
+    DOT = "DOT"
+    ETH = "ETH"
+    NEO = "NEO"
+    NULS = "NULS"
+    NULS2 = "NULS2"
+    SOL = "SOL"
+    TEZOS = "TEZOS"
+
+
+class HashType(str, Enum):
+    """Supported hash functions"""
+
+    sha256 = "sha256"
+
+
+class MessageType(str, Enum):
+    """Message types supported by Aleph"""
+
+    post = "POST"
+    aggregate = "AGGREGATE"
+    store = "STORE"
+    program = "PROGRAM"
+    instance = "INSTANCE"
+    forget = "FORGET"

--- a/aleph_message/models/execution/abstract.py
+++ b/aleph_message/models/execution/abstract.py
@@ -5,13 +5,10 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
-from .environment import (
-    FunctionEnvironment,
-    HostRequirements,
-    MachineResources,
-)
-from .volume import MachineVolume
 from ..abstract import BaseContent, HashableModel
+from .base import Payment
+from .environment import FunctionEnvironment, HostRequirements, MachineResources
+from .volume import MachineVolume
 
 
 class BaseExecutableContent(HashableModel, BaseContent, ABC):
@@ -29,6 +26,7 @@ class BaseExecutableContent(HashableModel, BaseContent, ABC):
         description="Properties of the execution environment"
     )
     resources: MachineResources = Field(description="System resources required")
+    payment: Optional[Payment] = Field(description="Payment details for the execution")
     requirements: Optional[HostRequirements] = Field(
         default=None, description="System properties required"
     )

--- a/aleph_message/models/execution/abstract.py
+++ b/aleph_message/models/execution/abstract.py
@@ -5,10 +5,14 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
-from ..abstract import BaseContent, HashableModel
+from .environment import (
+    FunctionEnvironment,
+    HostRequirements,
+    MachineResources,
+)
 from .base import Payment
-from .environment import FunctionEnvironment, HostRequirements, MachineResources
 from .volume import MachineVolume
+from ..abstract import BaseContent, HashableModel
 
 
 class BaseExecutableContent(HashableModel, BaseContent, ABC):

--- a/aleph_message/models/execution/base.py
+++ b/aleph_message/models/execution/base.py
@@ -27,7 +27,7 @@ class PaymentType(str, Enum):
     """Payment type for a program execution."""
 
     hold = "hold"
-    stream = "stream"
+    superfluid = "superfluid"
 
 
 class Payment(HashableModel):

--- a/aleph_message/models/execution/base.py
+++ b/aleph_message/models/execution/base.py
@@ -39,3 +39,7 @@ class Payment(HashableModel):
     """Optional alternative address to send tokens to"""
     type: PaymentType
     """Whether to pay by holding $ALEPH or by streaming tokens"""
+
+    @property
+    def is_stream(self):
+        return self.type == PaymentType.superfluid

--- a/aleph_message/models/execution/base.py
+++ b/aleph_message/models/execution/base.py
@@ -35,7 +35,7 @@ class Payment(HashableModel):
 
     chain: Chain
     """Which chain to check for funds"""
-    receiver_address: Optional[str]
+    receiver: Optional[str]
     """Optional alternative address to send tokens to"""
-    payment_type: PaymentType
+    type: PaymentType
     """Whether to pay by holding $ALEPH or by streaming tokens"""

--- a/aleph_message/models/execution/base.py
+++ b/aleph_message/models/execution/base.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Optional
+
+from ..abstract import HashableModel
+from ..base import Chain
 
 
 class Encoding(str, Enum):
@@ -17,3 +21,21 @@ class MachineType(str, Enum):
 
     vm_instance = "vm-instance"
     vm_function = "vm-function"
+
+
+class PaymentType(str, Enum):
+    """Payment type for a program execution."""
+
+    hold = "hold"
+    stream = "stream"
+
+
+class Payment(HashableModel):
+    """Payment information for a program execution."""
+
+    chain: Chain
+    """Which chain to check for funds"""
+    receiver_address: Optional[str]
+    """Optional alternative address to send tokens to"""
+    payment_type: PaymentType
+    """Whether to pay by holding $ALEPH or by streaming tokens"""


### PR DESCRIPTION
In preparation for the Superfluid pay-as-you-go option for Programs/Instances.