### PR TITLE
Add `version` field to `BaseMessage`

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -178,6 +178,9 @@ class ForgetContent(BaseContent):
 class BaseMessage(BaseModel):
     """Base template for all messages"""
 
+    version: Optional[int] = Field(
+        default=None, description="Version of the message format"
+    )
     id_: Optional[MongodbId] = Field(
         alias="_id",
         default=None,
@@ -185,7 +188,6 @@ class BaseMessage(BaseModel):
         exclude=True,
     )
     chain: Chain = Field(description="Blockchain used for this message")
-
     sender: str = Field(description="Address of the sender")
     type: MessageType = Field(description="Type of message (POST, AGGREGATE or STORE)")
     channel: Optional[str] = Field(


### PR DESCRIPTION
From the discussion about pay-as-you-go specs in https://github.com/aleph-im/aleph-message/pull/82#discussion_r1425112077:

> The chain used for payment should be the same as the chain of the sender and the receiver. The [chain field of the BaseMessage](https://github.com/aleph-im/aleph-message/blob/main/aleph_message/models/__init__.py#L187) class is not signed however.

> Then I'd just recommend changing the verification_buffer function to include the chain field (**and also a new version field describing the message spec version**)