### PR TITLE
Add `dump_content` function to avoid unclear `item_content` transformation process

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -11,9 +11,9 @@ from typing_extensions import TypeAlias
 
 from .abstract import BaseContent
 from .base import Chain, HashType, MessageType
+from .execution.base import MachineType, Payment, PaymentType  # noqa
 from .execution.instance import InstanceContent
 from .execution.program import ProgramContent
-from .execution.base import PaymentType, MachineType, Payment  # noqa
 from .item_hash import ItemHash, ItemType
 
 

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -202,37 +202,43 @@ class BaseMessage(BaseModel):
         return v
 
     @validator("content")
-    def check_content(cls, v, values):
+    def check_content(self, v, values):
+        """Check that the content matches the serialized item_content"""
         item_type = values["item_type"]
-        if item_type == ItemType.inline:
-            try:
-                item_content = json.loads(values["item_content"])
-            except JSONDecodeError:
-                raise ValueError(
-                    "Field 'item_content' does not appear to be valid JSON"
-                )
-            json_dump = json.loads(v.json())
-            for key, value in json_dump.items():
-                if value != item_content[key]:
-                    if isinstance(value, list):
-                        for item in value:
-                            if item not in item_content[key]:
-                                raise ValueError(
-                                    f"Field 'content.{key}' does not match 'item_content.{key}': {item} != {item_content[key]}"
-                                )
-                    if isinstance(value, dict):
-                        for item in value.items():
-                            if item not in item_content[key].items():
-                                raise ValueError(
-                                    f"Field 'content.{key}' does not match 'item_content.{key}': {value} != {item_content[key]}"
-                                )
+        if item_type != ItemType.inline:
+            return v
+
+        try:
+            item_content = json.loads(values["item_content"])
+        except JSONDecodeError:
+            raise ValueError("Field 'item_content' does not appear to be valid JSON")
+        json_dump = json.loads(v.json())
+        for key, value in json_dump.items():
+            if value != item_content[key]:
+                self._raise_value_error(item_content, key, value)
+
+    @staticmethod
+    def _raise_value_error(item_content, key, value):
+        """Raise a ValueError with a message that explains the content/item_content mismatch"""
+        if isinstance(value, list):
+            for item in value:
+                if item not in item_content[key]:
                     raise ValueError(
-                        f"Field 'content.{key}' does not match 'item_content.{key}': {value} != {item_content[key]} or type mismatch ({type(value)} != {type(item_content[key])})"
+                        f"Field 'content.{key}' does not match 'item_content.{key}': {item} != {item_content[key]}"
                     )
-        return v
+        if isinstance(value, dict):
+            for item in value.items():
+                if item not in item_content[key].items():
+                    raise ValueError(
+                        f"Field 'content.{key}' does not match 'item_content.{key}': {value} != {item_content[key]}"
+                    )
+        raise ValueError(
+            f"Field 'content.{key}' does not match 'item_content.{key}': {value} != {item_content[key]} or type mismatch ({type(value)} != {type(item_content[key])})"
+        )
 
     @validator("item_hash")
     def check_item_hash(cls, v: ItemHash, values) -> ItemHash:
+        """Check that the 'item_hash' matches the 'item_content's SHA256 hash"""
         item_type = values["item_type"]
         if item_type == ItemType.inline:
             item_content: str = values["item_content"]
@@ -256,6 +262,7 @@ class BaseMessage(BaseModel):
 
     @validator("confirmed")
     def check_confirmed(cls, v, values):
+        """Check that 'confirmed' is not True without 'confirmations'"""
         confirmations = values["confirmations"]
         if v is True and not bool(confirmations):
             raise ValueError("Message cannot be 'confirmed' without 'confirmations'")
@@ -263,6 +270,7 @@ class BaseMessage(BaseModel):
 
     @validator("time")
     def convert_float_to_datetime(cls, v, values):
+        """Converts a Unix timestamp to a datetime object"""
         if isinstance(v, float):
             v = datetime.datetime.fromtimestamp(v)
         assert isinstance(v, datetime.datetime)

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -202,7 +202,7 @@ class BaseMessage(BaseModel):
         return v
 
     @validator("content")
-    def check_content(self, v, values):
+    def check_content(cls, v, values):
         """Check that the content matches the serialized item_content"""
         item_type = values["item_type"]
         if item_type != ItemType.inline:
@@ -215,7 +215,8 @@ class BaseMessage(BaseModel):
         json_dump = json.loads(v.json())
         for key, value in json_dump.items():
             if value != item_content[key]:
-                self._raise_value_error(item_content, key, value)
+                cls._raise_value_error(item_content, key, value)
+        return v
 
     @staticmethod
     def _raise_value_error(item_content, key, value):

--- a/aleph_message/models/abstract.py
+++ b/aleph_message/models/abstract.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel, Extra
 
+from aleph_message.utils import dump_content
+
 
 def hashable(obj):
     """Convert `obj` into a hashable object."""
@@ -26,3 +28,6 @@ class BaseContent(BaseModel):
 
     class Config:
         extra = Extra.forbid
+
+    def json(self, *args, **kwargs):
+        return dump_content(self)

--- a/aleph_message/models/execution/abstract.py
+++ b/aleph_message/models/execution/abstract.py
@@ -5,14 +5,10 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import Field
 
-from .environment import (
-    FunctionEnvironment,
-    HostRequirements,
-    MachineResources,
-)
-from .base import Payment
-from .volume import MachineVolume
 from ..abstract import BaseContent, HashableModel
+from .base import Payment
+from .environment import FunctionEnvironment, HostRequirements, MachineResources
+from .volume import MachineVolume
 
 
 class BaseExecutableContent(HashableModel, BaseContent, ABC):

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Optional, List
+from typing import List, Literal, Optional
 
 from pydantic import Field
 

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -271,12 +271,12 @@ def test_create_new_message():
         "chain": "ETH",
         "sender": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
         "type": "POST",
-        "time": "1625652287.017",
+        "time": 1625652287.017,
         "item_type": "inline",
         "content": {
             "address": "0x101d8D16372dBf5f1614adaE95Ee5CCE61998Fc9",
             "type": "test-message",
-            "time": "1625652287.017",
+            "time": 1625652287.017,
             "content": {
                 "hello": "world",
             },

--- a/aleph_message/tests/test_utils.py
+++ b/aleph_message/tests/test_utils.py
@@ -1,9 +1,14 @@
-from datetime import datetime, date, time
+from datetime import date, datetime, time
 
 import pytest
 from pydantic import BaseModel
 
-from aleph_message.utils import Gigabytes, gigabyte_to_mebibyte, extended_json_encoder, dump_content
+from aleph_message.utils import (
+    Gigabytes,
+    dump_content,
+    extended_json_encoder,
+    gigabyte_to_mebibyte,
+)
 
 
 def test_gigabyte_to_mebibyte():
@@ -25,8 +30,13 @@ def test_dump_content():
         address: str
         time: float
 
-    assert dump_content({"address": "0x1", "time": 1.0}) == '{"address":"0x1","time":1.0}'
-    assert dump_content(TestModel(address="0x1", time=1.0)) == '{"address":"0x1","time":1.0}'
+    assert (
+        dump_content({"address": "0x1", "time": 1.0}) == '{"address":"0x1","time":1.0}'
+    )
+    assert (
+        dump_content(TestModel(address="0x1", time=1.0))
+        == '{"address":"0x1","time":1.0}'
+    )
 
 
 @pytest.mark.parametrize(

--- a/aleph_message/tests/test_utils.py
+++ b/aleph_message/tests/test_utils.py
@@ -1,6 +1,43 @@
-from aleph_message.utils import Gigabytes, gigabyte_to_mebibyte
+from datetime import datetime, date, time
+
+import pytest
+from pydantic import BaseModel
+
+from aleph_message.utils import Gigabytes, gigabyte_to_mebibyte, extended_json_encoder, dump_content
 
 
 def test_gigabyte_to_mebibyte():
     assert gigabyte_to_mebibyte(Gigabytes(1)) == 954
     assert gigabyte_to_mebibyte(Gigabytes(100)) == 95368
+
+
+def test_extended_json_encoder():
+    now = datetime.now()
+    today = date.today()
+    now_time = time(hour=1, minute=2, second=3, microsecond=4)
+    assert extended_json_encoder(now) == now.timestamp()
+    assert extended_json_encoder(today) == today.toordinal()
+    assert extended_json_encoder(now_time) == 3723.000004
+
+
+def test_dump_content():
+    class TestModel(BaseModel):
+        address: str
+        time: float
+
+    assert dump_content({"address": "0x1", "time": 1.0}) == '{"address":"0x1","time":1.0}'
+    assert dump_content(TestModel(address="0x1", time=1.0)) == '{"address":"0x1","time":1.0}'
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        1,
+        "test",
+        None,
+        True,
+    ],
+)
+def test_dump_content_invalid(content):
+    with pytest.raises(TypeError):
+        dump_content(content)

--- a/aleph_message/utils.py
+++ b/aleph_message/utils.py
@@ -40,17 +40,13 @@ def dump_content(obj: Union[Dict, BaseModel]) -> str:
     """Dump message content as JSON string."""
     if isinstance(obj, dict):
         # without None values
-        obj = obj.copy()
-        for key in list(obj.keys()):
-            if obj[key] is None:
-                del obj[key]
+        obj = {k: v for k, v in obj.items() if v is not None}
         return json.dumps(obj, separators=(",", ":"), default=extended_json_encoder)
-
-    if isinstance(obj, BaseModel):
+    elif isinstance(obj, BaseModel):
         return json.dumps(
             obj.dict(exclude_none=True),
             separators=(",", ":"),
             default=extended_json_encoder,
         )
-
-    raise TypeError(f"Invalid type: `{type(obj)}`")
+    else:
+        raise TypeError(f"Invalid type: `{type(obj)}`")

--- a/aleph_message/utils.py
+++ b/aleph_message/utils.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import json
 import math
-from typing import NewType
+from datetime import date, datetime, time
+from typing import Any, Dict, NewType, Union
+
+from pydantic import BaseModel
+from pydantic.json import pydantic_encoder
 
 Megabytes = NewType("Megabytes", int)
 Mebibytes = NewType("Mebibytes", int)
@@ -15,3 +20,37 @@ def gigabyte_to_mebibyte(n: Gigabytes) -> Mebibytes:
     mebibyte = 2**20
     gigabyte = 10**9
     return Mebibytes(math.ceil(n * gigabyte / mebibyte))
+
+
+def extended_json_encoder(obj: Any) -> Any:
+    """
+    Extended JSON encoder for dumping objects that contain pydantic models and datetime objects.
+    """
+    if isinstance(obj, datetime):
+        return obj.timestamp()
+    elif isinstance(obj, date):
+        return obj.toordinal()
+    elif isinstance(obj, time):
+        return obj.hour * 3600 + obj.minute * 60 + obj.second + obj.microsecond / 1e6
+    else:
+        return pydantic_encoder(obj)
+
+
+def dump_content(obj: Union[Dict, BaseModel]) -> str:
+    """Dump message content as JSON string."""
+    if isinstance(obj, dict):
+        # without None values
+        obj = obj.copy()
+        for key in list(obj.keys()):
+            if obj[key] is None:
+                del obj[key]
+        return json.dumps(obj, separators=(",", ":"), default=extended_json_encoder)
+
+    if isinstance(obj, BaseModel):
+        return json.dumps(
+            obj.dict(exclude_none=True),
+            separators=(",", ":"),
+            default=extended_json_encoder,
+        )
+
+    raise TypeError(f"Invalid type: `{type(obj)}`")


### PR DESCRIPTION
In order to avoid mistakes when creating the `item_content` of a message, the [`extended_json_encoder`](https://github.com/aleph-im/aleph-sdk-python/blob/main/src/aleph/sdk/utils.py#L153) has been added from the `aleph-sdk-python` package to this central piece of the aleph architecture.

Based on #89 