### PR TITLE
Fix: Requirements were too strict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     data_files=[],
     install_requires=[
-        "pydantic>=1.10.5",
+        "pydantic>=1.10.5;<2.0.0",
         "typing_extensions>=4.5.0",
     ],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     },
     data_files=[],
     install_requires=[
-        "pydantic>=1.10.5;<2.0.0",
+        "pydantic>=1.10.5,<2.0.0",
         "typing_extensions>=4.5.0",
     ],
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,8 @@ setup(
     },
     data_files=[],
     install_requires=[
-        "pydantic~=1.10.5",
-        "typing_extensions~=4.5.0",
+        "pydantic>=1.10.5",
+        "typing_extensions>=4.5.0",
     ],
     license="MIT",
     platform="any",


### PR DESCRIPTION
This made it impossible to install aleph-message together with fastapi
0.109.2

```
The conflict is caused by:
    The user requested typing-extensions>=4.8.0
    aleph-sdk-python 0.9.0 depends on typing-extensions
    fastapi 0.109.2 depends on typing-extensions>=4.8.0
    aleph-message 0.4.3 depends on typing-extensions~=4.5.0
```

Solution: Require version at least than instead of similar to.
