### PR TITLE
Feat: The max size of an instance for PAYG model is too low

### DIFF
--- a/aleph_message/models/execution/volume.py
+++ b/aleph_message/models/execution/volume.py
@@ -32,7 +32,7 @@ class ImmutableVolume(AbstractVolume):
 
 class EphemeralVolumeSize(ConstrainedInt):
     gt = 0
-    le = 1000  # Limit to 1 GiB
+    le = gigabyte_to_mebibyte(10)  # Limit to 10 GB
     strict = True
 
 
@@ -60,8 +60,8 @@ class VolumePersistence(str, Enum):
 
 class PersistentVolumeSizeMib(ConstrainedInt):
     gt = 0
-    le = gigabyte_to_mebibyte(Gigabytes(100))
-    strict = True  # Limit to 100 GiB
+    le = gigabyte_to_mebibyte(Gigabytes(1_000))
+    strict = True  # Limit to 1 TB
 
 
 class PersistentVolume(AbstractVolume):

--- a/aleph_message/models/execution/volume.py
+++ b/aleph_message/models/execution/volume.py
@@ -32,7 +32,7 @@ class ImmutableVolume(AbstractVolume):
 
 class EphemeralVolumeSize(ConstrainedInt):
     gt = 0
-    le = gigabyte_to_mebibyte(10)  # Limit to 10 GB
+    le = gigabyte_to_mebibyte(Gigabytes(10))  # Limit to 10 GB
     strict = True
 
 


### PR DESCRIPTION
The PAYG model only allows VMs below 100 Gib. This change will allow bigger VMs (up to 1 TB) being eligible for PAYG model.
Solution: Adjust the max size of Persistent Volume to 1TB instead of 100 Gib Same for the Ephemeral volume now its limit is 10GB