### PR TITLE
fix: add MANIFEST.in to ship py.typed files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+recursive-include aleph_message *.py
+recursive-include aleph_message *.json
+
+include aleph_message/py.typed
+include LICENSE
+include pytest.ini
+include test.sh
+include Dockerfile
+include .dockerignore


### PR DESCRIPTION
Hello,

Currently this repository is missing a MANIFEST.in file, thus a lot of things are missing from the shipped package on pypi included the py.typed file which prevents mypy from working.

You can see a proof of that in this shell session:

![2024-05-02_17-46](https://github.com/aleph-im/aleph-message/assets/41827/8334bf4c-b345-4c32-ab69-d96b96a13b61)

And a working version using this PR:

![image](https://github.com/aleph-im/aleph-message/assets/41827/0f16b980-d148-49b9-9770-bc123953aa3f)

For additionnal work you probably want to add a github action that uses [check-manifest](https://github.com/mgedmin/check-manifest) to avoid this situation again.

Kind regards,