### PR TITLE
Add CPU features filter for executables

### DIFF
--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -77,6 +77,12 @@ class CpuProperties(HashableModel):
     vendor: Optional[Union[Literal["AuthenticAMD", "GenuineIntel"], str]] = Field(
         default=None, description="CPU vendor. Allows other vendors."
     )
+    # Features described here share the naming conventions of CPU flags (/proc/cpuinfo)
+    # but differ in that they must be actually available to the VM.
+    features: Optional[List[str]] = Field(
+        default=None,
+        description="CPU features required by the virtual machine. Examples: 'sev', 'sev_es', 'sev_snp'.",
+    )
 
     class Config:
         extra = Extra.forbid


### PR DESCRIPTION
Fix: CPU features required for execution could not be specified.

This allows the user to specify CPU features the CPU that must be available in order to run the VM.

This should help with automatic and manual scheduling to the right machines.

@aliel , this should help for running CPU intensive software that takes advantage of avx2, fma, f16c :wink: 