### PR TITLE
Fix: Models were not exposed as public in `aleph_message.models`.

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -11,10 +11,40 @@ from typing_extensions import TypeAlias
 
 from .abstract import BaseContent
 from .base import Chain, HashType, MessageType
-from .execution.base import MachineType, Payment, PaymentType  # noqa
+from .execution.base import MachineType, Payment, PaymentType
 from .execution.instance import InstanceContent
 from .execution.program import ProgramContent
 from .item_hash import ItemHash, ItemType
+
+__all__ = [
+    "AggregateContent",
+    "AggregateMessage",
+    "AlephMessage",
+    "AlephMessageType",
+    "Chain",
+    "ChainRef",
+    "ExecutableContent",
+    "ExecutableMessage",
+    "ForgetContent",
+    "ForgetMessage",
+    "HashType",
+    "InstanceContent",
+    "InstanceMessage",
+    "ItemHash",
+    "ItemType",
+    "MachineType",
+    "MessageConfirmation",
+    "MessageConfirmationHash",
+    "MessageType",
+    "Payment",
+    "PaymentType",
+    "PostContent",
+    "PostMessage",
+    "ProgramContent",
+    "ProgramMessage",
+    "StoreContent",
+    "StoreMessage",
+]
 
 
 class MongodbId(BaseModel):


### PR DESCRIPTION
This caused issues from Mypy in the form `error: Module "aleph_message.models" does not explicitly export attribute "MessageType"  [attr-defined]`

Solution: Expose models that should be public.