### PR TITLE
chore: configure dependabot to auto update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "pip"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Right now most of our dependencies are totally outdated, especially since we
pin all of them all the time and forget to check them after that.

This uses github dependabot built-in feature to do that.

Hopefully this will work with our usage of hatch.

You can see the related documentation here:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates

And some blog post here:
https://github.blog/news-insights/product-news/keep-all-your-packages-up-to-date-with-dependabot/

If this works here, I'll migrate our other projects on this.
