### PR TITLE
Fix: is_stream to be compatible with any new stream providers

### DIFF
--- a/aleph_message/models/execution/base.py
+++ b/aleph_message/models/execution/base.py
@@ -42,7 +42,7 @@ class Payment(HashableModel):
 
     @property
     def is_stream(self):
-        return self.type == PaymentType.superfluid
+        return self.type != PaymentType.hold
 
 
 class Interface(str, Enum):


### PR DESCRIPTION
Changing the condition to:
```python
self.type != PaymentType.hold
```
will allow us to add any new stream providers, other than superfluid, and still return "True"