### PR TITLE
Fix: max value of PersistentVolumeSizeMib to 512 GB

### DIFF
--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -25,7 +25,7 @@ class RootfsVolume(HashableModel):
     persistence: VolumePersistence
     # Use the same size constraint as persistent volumes for now
     size_mib: int = Field(
-        gt=-1, le=gigabyte_to_mebibyte(Gigabytes(100)), strict=True  # Limit to 1GiB
+        gt=-1, le=gigabyte_to_mebibyte(Gigabytes(512)), strict=True  # Limit to 1GiB
     )
     forgotten_by: Optional[List[str]] = None
 

--- a/aleph_message/models/execution/volume.py
+++ b/aleph_message/models/execution/volume.py
@@ -58,7 +58,7 @@ class PersistentVolume(AbstractVolume):
     persistence: Optional[VolumePersistence] = None
     name: Optional[str] = None
     size_mib: int = Field(
-        gt=0, le=gigabyte_to_mebibyte(Gigabytes(100)), strict=True  # Limit to 100GiB
+        gt=0, le=gigabyte_to_mebibyte(Gigabytes(512)), strict=True  # Limit to 512GiB
     )
 
     def is_read_only(self):

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -375,10 +375,10 @@ def test_volume_size_constraints():
     # A ValidationError should be raised if the size negative
     with pytest.raises(ValidationError):
         _ = create_test_rootfs(size_mib=-1)
-    size_mib_rootfs: Mebibytes = gigabyte_to_mebibyte(Gigabytes(100))
-    # A size of 100GiB should be allowed
+    size_mib_rootfs: Mebibytes = gigabyte_to_mebibyte(Gigabytes(512))
+    # A size of 512 GiB should be allowed
     _ = create_test_rootfs(size_mib=size_mib_rootfs)
-    # A ValidationError should be raised if the size is greater than 100GiB
+    # A ValidationError should be raised if the size is greater than 512 GiB
     with pytest.raises(ValidationError):
         _ = create_test_rootfs(size_mib=size_mib_rootfs + 1)
 


### PR DESCRIPTION
Problem:

Instance Persistent Volume is currently limited to `100` GB, this value goes to `512` GB