### PR TITLE
Added new EVM chains

### DIFF
--- a/aleph_message/models/base.py
+++ b/aleph_message/models/base.py
@@ -4,17 +4,31 @@ from enum import Enum
 class Chain(str, Enum):
     """Supported chains"""
 
+    ARBITRUM = "ARB"
     AVAX = "AVAX"
     BASE = "BASE"
+    BLAST = "BLAST"
+    BOB = "BOB"
     BSC = "BSC"
     CSDK = "CSDK"
+    CYBER = "CYBER"
     DOT = "DOT"
     ETH = "ETH"
+    FRAXTAL = "FRAX"
+    INK = "INK"
+    LINEA = "LINEA"
+    LISK = "LISK"
+    METIS = "METIS"
+    MODE = "MODE"
     NEO = "NEO"
     NULS = "NULS"
     NULS2 = "NULS2"
+    OPTIMISM = "OP"
+    POL = "POL"
     SOL = "SOL"
     TEZOS = "TEZOS"
+    WORLDCHAIN = "WLD"
+    ZORA = "ZORA"
 
 
 class HashType(str, Enum):


### PR DESCRIPTION
Implemented support for this new EVM chains:
```
    ARBITRUM = "ARB"
    BLAST = "BLAST"
    BOB = "BOB"
    CYBER = "CYBER"
    FRAXTAL = "FRAX"
    INK = "INK"
    LINEA = "LINEA"
    LISK = "LISK"
    METIS = "METIS"
    MODE = "MODE"
    OPTIMISM = "OP"
    POL = "POL"
    WORLDCHAIN = "WLD"
    ZORA = "ZORA"
```