### PR TITLE
fix: remove metadata field on `StoreMessage`

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -295,7 +295,6 @@ class StoreMessage(BaseMessage):
     type: Literal[MessageType.store]
     content: StoreContent
     forgotten_by: Optional[list] = None
-    metadata: Optional[Dict[str, Any]] = None
 
 
 class ForgetMessage(BaseMessage):


### PR DESCRIPTION
This field is a duplicate of `StoreContent.metadata` and is unsafe to use as it is not part of the signed payload. This should not cause issues as the field is not stored in DB on CCNs anyway.