### PR TITLE
fix: volume refs incorrectly use optional refs

### DIFF
--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -43,9 +43,11 @@ class DataContent(HashableModel):
 
     encoding: Encoding
     mount: str
-    ref: Optional[ItemHash] = None
+    ref: ItemHash
     use_latest: Optional[bool] = False
 
+    def use_latest_image(self) -> bool:
+        return self.use_latest or False
 
 class Export(HashableModel):
     """Data to export after computations."""

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -49,6 +49,7 @@ class DataContent(HashableModel):
     def use_latest_image(self) -> bool:
         return self.use_latest or False
 
+
 class Export(HashableModel):
     """Data to export after computations."""
 

--- a/aleph_message/models/execution/volume.py
+++ b/aleph_message/models/execution/volume.py
@@ -22,7 +22,7 @@ class AbstractVolume(HashableModel, ABC):
 
 
 class ImmutableVolume(AbstractVolume):
-    ref: Optional[ItemHash] = None
+    ref: ItemHash
     use_latest: bool = True
 
     def is_read_only(self):


### PR DESCRIPTION
Fixed an issue in `DataContent` and `ImmutableVolume` where the volume
reference (=item hash) can be optional. This makes no sense as these
volumes need to be fetched from the network.