### PR TITLE
Harden aleph-message validation (C1, M1, M3, M5-M9, L3)

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -20,6 +20,11 @@ from .item_hash import ItemHash, ItemType
 logger = logging.getLogger(__name__)
 
 
+MAX_CHANNEL_LENGTH = 128
+MAX_FORGET_TARGETS = 1000
+MAX_FORGET_REASON_LENGTH = 1000
+
+
 __all__ = [
     "AggregateContent",
     "AggregateMessage",
@@ -65,7 +70,7 @@ class ChainRef(BaseModel):
     """Some POST messages have a 'ref' field referencing other content"""
 
     chain: Chain
-    channel: Optional[str] = None
+    channel: Optional[str] = Field(default=None, max_length=MAX_CHANNEL_LENGTH)
     item_content: str
     item_hash: ItemHash
     item_type: ItemType
@@ -165,10 +170,6 @@ class StoreContent(BaseContent):
     model_config = ConfigDict(extra="allow")
 
 
-MAX_FORGET_TARGETS = 1000
-MAX_FORGET_REASON_LENGTH = 1000
-
-
 class ForgetContent(BaseContent):
     """Content of a FORGET message"""
 
@@ -200,6 +201,7 @@ class BaseMessage(BaseModel):
     type: MessageType = Field(description="Type of message (POST, AGGREGATE or STORE)")
     channel: Optional[str] = Field(
         default=None,
+        max_length=MAX_CHANNEL_LENGTH,
         description="Channel of the message, one application ideally has one channel",
     )
     confirmations: Optional[List[MessageConfirmation]] = Field(

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -167,7 +167,11 @@ class StoreContent(BaseContent):
             )
         return v
 
-    model_config = ConfigDict(extra="allow")
+    # `extra="ignore"` drops unknown fields silently rather than preserving
+    # them (previous `extra="allow"`) or rejecting the message outright
+    # (`extra="forbid"`). Messages in the wild may contain legacy extras;
+    # "ignore" keeps them accepted without widening the persistence surface.
+    model_config = ConfigDict(extra="ignore")
 
 
 class ForgetContent(BaseContent):

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -249,9 +249,12 @@ class BaseMessage(BaseModel):
         if item_type == ItemType.inline:
             item_content: str = values.data.get("item_content")
 
-            # Double check that the hash function is supported
+            # Double check that the hash function is supported.
             hash_type = values.data.get("hash_type") or HashType.sha256
-            assert hash_type.value == HashType.sha256
+            if hash_type.value != HashType.sha256:
+                raise ValueError(
+                    f"Unsupported hash type '{hash_type.value}', expected 'sha256'"
+                )
 
             computed_hash: str = sha256(item_content.encode()).hexdigest()
             if v != computed_hash:
@@ -262,8 +265,8 @@ class BaseMessage(BaseModel):
         elif item_type == ItemType.ipfs:
             # TODO: CHeck that the hash looks like an IPFS multihash
             pass
-        else:
-            assert item_type == ItemType.storage
+        elif item_type != ItemType.storage:
+            raise ValueError(f"Unknown item_type '{item_type}'")
         return v
 
     @field_validator("confirmed")

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -165,12 +165,18 @@ class StoreContent(BaseContent):
     model_config = ConfigDict(extra="allow")
 
 
+MAX_FORGET_TARGETS = 1000
+MAX_FORGET_REASON_LENGTH = 1000
+
+
 class ForgetContent(BaseContent):
     """Content of a FORGET message"""
 
-    hashes: List[ItemHash]
-    aggregates: List[ItemHash] = Field(default_factory=list)
-    reason: Optional[str] = None
+    hashes: List[ItemHash] = Field(max_length=MAX_FORGET_TARGETS)
+    aggregates: List[ItemHash] = Field(
+        default_factory=list, max_length=MAX_FORGET_TARGETS
+    )
+    reason: Optional[str] = Field(default=None, max_length=MAX_FORGET_REASON_LENGTH)
 
     def __hash__(self):
         # Convert List to Tuple for hashing

--- a/aleph_message/models/abstract.py
+++ b/aleph_message/models/abstract.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
+# Unix timestamp upper bound (year 2262). Well below the float-precision
+# cliff at 2**53 while still leaving headroom for any realistic message.
+MAX_CONTENT_TIME = 9_223_372_036.0
 
 
 def hashable(obj):
@@ -22,6 +26,6 @@ class BaseContent(BaseModel):
     """Base template for message content"""
 
     address: str
-    time: float
+    time: float = Field(ge=0, le=MAX_CONTENT_TIME)
 
     model_config = ConfigDict(extra="forbid")

--- a/aleph_message/models/execution/abstract.py
+++ b/aleph_message/models/execution/abstract.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Annotated, Any, Dict, List, Optional, Sequence, Union
 
 from pydantic import Field
 
@@ -16,17 +16,38 @@ from .environment import (
 )
 from .volume import MachineVolume
 
+MAX_METADATA_ENTRIES = 256
+MAX_AUTHORIZED_KEYS = 256
+MAX_AUTHORIZED_KEY_LENGTH = 8192
+MAX_VARIABLE_ENTRIES = 256
+MAX_VARIABLE_KEY_LENGTH = 128
+MAX_VARIABLE_VALUE_LENGTH = 4096
+MAX_VOLUMES = 256
+MAX_REPLACES_LENGTH = 128
+
+VariableKey = Annotated[str, Field(max_length=MAX_VARIABLE_KEY_LENGTH)]
+VariableValue = Annotated[str, Field(max_length=MAX_VARIABLE_VALUE_LENGTH)]
+AuthorizedKey = Annotated[str, Field(max_length=MAX_AUTHORIZED_KEY_LENGTH)]
+
 
 class BaseExecutableContent(HashableModel, BaseContent, ABC):
     """Abstract content for execution messages (Instances, Programs)."""
 
     allow_amend: bool = Field(description="Allow amends to update this function")
-    metadata: Optional[Dict[str, Any]] = Field(description="Metadata of the VM")
-    authorized_keys: Optional[List[str]] = Field(
+    metadata: Optional[Dict[str, Any]] = Field(
+        default=None,
+        max_length=MAX_METADATA_ENTRIES,
+        description="Metadata of the VM",
+    )
+    authorized_keys: Optional[List[AuthorizedKey]] = Field(
+        default=None,
+        max_length=MAX_AUTHORIZED_KEYS,
         description="SSH public keys authorized to connect to the VM",
     )
-    variables: Optional[Dict[str, str]] = Field(
-        default=None, description="Environment variables available in the VM"
+    variables: Optional[Dict[VariableKey, VariableValue]] = Field(
+        default=None,
+        max_length=MAX_VARIABLE_ENTRIES,
+        description="Environment variables available in the VM",
     )
     environment: Union[FunctionEnvironment, InstanceEnvironment] = Field(
         description="Properties of the execution environment"
@@ -37,10 +58,13 @@ class BaseExecutableContent(HashableModel, BaseContent, ABC):
         default=None, description="System properties required"
     )
     volumes: List[MachineVolume] = Field(
-        default=[], description="Volumes to mount on the filesystem"
+        default=[],
+        max_length=MAX_VOLUMES,
+        description="Volumes to mount on the filesystem",
     )
     replaces: Optional[str] = Field(
         default=None,
+        max_length=MAX_REPLACES_LENGTH,
         description="Previous version to replace. Must be signed by the same address",
     )
 

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from enum import Enum
 from typing import List, Literal, Optional, Union
 
@@ -8,6 +9,8 @@ from pydantic import ConfigDict, Field, field_validator
 from ...utils import Mebibytes
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
+
+MAX_ADDRESS_REGEX_LENGTH = 256
 
 
 class Subscription(HashableModel):
@@ -176,7 +179,9 @@ class InstanceEnvironment(HashableModel):
 class NodeRequirements(HashableModel):
     owner: Optional[str] = Field(default=None, description="Address of the node owner")
     address_regex: Optional[str] = Field(
-        default=None, description="Node address must match this regular expression"
+        default=None,
+        max_length=MAX_ADDRESS_REGEX_LENGTH,
+        description="Node address must match this regular expression",
     )
     node_hash: Optional[ItemHash] = Field(
         default=None, description="Hash of the compute resource node that must be used"
@@ -186,6 +191,16 @@ class NodeRequirements(HashableModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("address_regex")
+    def check_address_regex_compiles(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            re.compile(v)
+        except re.error as exc:
+            raise ValueError(f"Invalid regular expression: {exc}") from exc
+        return v
 
 
 class HostRequirements(HashableModel):

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -61,10 +61,17 @@ class PortMapping(PublishedPort):
     )
 
 
+MAX_VCPUS = 256
+MAX_MEMORY_MIB = 1024 * 1024  # 1 TiB
+# ~10 years expressed in seconds. Guards against overflow in downstream
+# cost calculations while remaining high enough for long-running instances.
+MAX_SECONDS = 10 * 365 * 24 * 3600
+
+
 class MachineResources(HashableModel):
-    vcpus: int = 1
-    memory: Mebibytes = Mebibytes(128)
-    seconds: int = 1
+    vcpus: int = Field(default=1, ge=1, le=MAX_VCPUS)
+    memory: Mebibytes = Field(default=Mebibytes(128), ge=1, le=MAX_MEMORY_MIB)
+    seconds: int = Field(default=1, ge=1, le=MAX_SECONDS)
     published_ports: Optional[List[PublishedPort]] = Field(
         default=None, description="IPv4 ports to map to open ports on the host."
     )

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -4,17 +4,31 @@ import re
 from enum import Enum
 from typing import List, Literal, Optional, Union
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from ...utils import Mebibytes
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
 
 MAX_ADDRESS_REGEX_LENGTH = 256
+MAX_SUBSCRIPTION_ENTRIES = 32
 
 
 class Subscription(HashableModel):
     """A subscription is used to trigger a program in response to a FunctionTrigger."""
+
+    # Subscriptions are user-defined filter criteria; the model intentionally
+    # accepts arbitrary keys. Cap the number of entries so a subscription
+    # object can't be padded with hundreds of keys.
+    @model_validator(mode="after")
+    def check_subscription_size(self) -> "Subscription":
+        extra = self.__pydantic_extra__ or {}
+        if len(extra) > MAX_SUBSCRIPTION_ENTRIES:
+            raise ValueError(
+                f"Subscription has {len(extra)} entries, "
+                f"maximum allowed is {MAX_SUBSCRIPTION_ENTRIES}"
+            )
+        return self
 
     model_config = ConfigDict(extra="allow")
 
@@ -159,7 +173,7 @@ class TrustedExecutionEnvironment(HashableModel):
         description="Policy of the TEE. Default value is 0x01 for SEV without debugging.",
     )
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class InstanceEnvironment(HashableModel):
@@ -225,4 +239,4 @@ class HostRequirements(HashableModel):
     def gpu_requirements(self):
         return self.gpu or []
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")

--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import Field, model_validator
 from typing_extensions import Self
 
 from aleph_message.models.abstract import HashableModel
 
-from .abstract import BaseExecutableContent
+from .abstract import (
+    MAX_AUTHORIZED_KEYS,
+    MAX_METADATA_ENTRIES,
+    AuthorizedKey,
+    BaseExecutableContent,
+)
 from .base import Payment
 from .environment import HypervisorType, InstanceEnvironment
 from .volume import ParentVolume, PersistentVolumeSizeMib, VolumePersistence
@@ -31,10 +36,12 @@ class RootfsVolume(HashableModel):
 class InstanceContent(BaseExecutableContent):
     """Message content for scheduling a VM instance on the network."""
 
-    metadata: Optional[dict] = None
+    metadata: Optional[Dict] = Field(default=None, max_length=MAX_METADATA_ENTRIES)
     payment: Optional[Payment] = None
-    authorized_keys: Optional[List[str]] = Field(
-        default=None, description="List of authorized SSH keys"
+    authorized_keys: Optional[List[AuthorizedKey]] = Field(
+        default=None,
+        max_length=MAX_AUTHORIZED_KEYS,
+        description="List of authorized SSH keys",
     )
     environment: InstanceEnvironment = Field(
         description="Properties of the instance execution environment"

--- a/aleph_message/models/execution/program.py
+++ b/aleph_message/models/execution/program.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from pydantic import Field
 
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
-from .abstract import BaseExecutableContent
+from .abstract import (
+    MAX_AUTHORIZED_KEYS,
+    MAX_METADATA_ENTRIES,
+    AuthorizedKey,
+    BaseExecutableContent,
+)
 from .base import Encoding, Interface, MachineType, Payment
 from .environment import FunctionTriggers
 
@@ -73,6 +78,8 @@ class ProgramContent(BaseExecutableContent):
     )
     on: FunctionTriggers = Field(description="Signals that trigger an execution")
 
-    metadata: Optional[dict] = None
-    authorized_keys: Optional[List[str]] = None
+    metadata: Optional[Dict] = Field(default=None, max_length=MAX_METADATA_ENTRIES)
+    authorized_keys: Optional[List[AuthorizedKey]] = Field(
+        default=None, max_length=MAX_AUTHORIZED_KEYS
+    )
     payment: Optional[Payment] = None

--- a/aleph_message/models/execution/volume.py
+++ b/aleph_message/models/execution/volume.py
@@ -11,9 +11,12 @@ from ..abstract import HashableModel
 from ..item_hash import ItemHash
 
 
+MAX_VOLUME_LABEL_LENGTH = 256
+
+
 class AbstractVolume(HashableModel, ABC):
-    comment: Optional[str] = None
-    mount: Optional[str] = None
+    comment: Optional[str] = Field(default=None, max_length=MAX_VOLUME_LABEL_LENGTH)
+    mount: Optional[str] = Field(default=None, max_length=MAX_VOLUME_LABEL_LENGTH)
 
     @abstractmethod
     def is_read_only(self): ...
@@ -75,7 +78,7 @@ PersistentVolumeSizeMib = Annotated[
 class PersistentVolume(AbstractVolume):
     parent: Optional[ParentVolume] = None
     persistence: Optional[VolumePersistence] = None
-    name: Optional[str] = None
+    name: Optional[str] = Field(default=None, max_length=MAX_VOLUME_LABEL_LENGTH)
     size_mib: PersistentVolumeSizeMib
 
     def is_read_only(self):

--- a/aleph_message/models/item_hash.py
+++ b/aleph_message/models/item_hash.py
@@ -1,3 +1,4 @@
+import re
 from enum import Enum
 from functools import lru_cache
 from typing import Any
@@ -5,6 +6,16 @@ from typing import Any
 from pydantic_core import core_schema
 
 from ..exceptions import UnknownHashError
+
+# SHA-256 hex digest used as the `storage` item hash.
+_STORAGE_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+# CIDv0 is base58btc-encoded. Base58btc excludes 0, O, I and l to avoid
+# visually-ambiguous characters.
+_CIDV0_RE = re.compile(r"^Qm[1-9A-HJ-NP-Za-km-z]{42,44}$")
+# CIDv1 emitted by the previous heuristic used the `bafy` multibase+codec
+# prefix followed by base32 (RFC 4648, lowercase, no padding). Keep the
+# same length as before (59 chars total) and validate the alphabet.
+_CIDV1_RE = re.compile(r"^bafy[a-z2-7]{55}$")
 
 
 class ItemType(str, Enum):
@@ -18,14 +29,13 @@ class ItemType(str, Enum):
     @lru_cache
     def from_hash(cls, item_hash: str) -> "ItemType":
         # https://docs.ipfs.io/concepts/content-addressing/#identifier-formats
-        if item_hash.startswith("Qm") and 44 <= len(item_hash) <= 46:  # CIDv0
+        if _CIDV0_RE.match(item_hash):
             return cls.ipfs
-        elif item_hash.startswith("bafy") and len(item_hash) == 59:  # CIDv1
+        if _CIDV1_RE.match(item_hash):
             return cls.ipfs
-        elif len(item_hash) == 64:
+        if _STORAGE_HASH_RE.match(item_hash):
             return cls.storage
-        else:
-            raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
+        raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
 
     @classmethod
     def is_storage(cls, item_hash: str):

--- a/aleph_message/tests/test_types.py
+++ b/aleph_message/tests/test_types.py
@@ -75,3 +75,31 @@ def test_bad_item_hashes():
     # UnknownHashError should be a ValueError
     with pytest.raises(ValueError):
         ItemHash("This is not a hash !")
+
+
+def test_storage_hash_rejects_non_hex():
+    # 64-char non-hex strings (previously accepted) must now be rejected.
+    with pytest.raises(UnknownHashError):
+        ItemHash(".//" + "../" * 12 + "root/.ssh/authorized_keys")  # path-traversal
+    with pytest.raises(UnknownHashError):
+        ItemHash("X" * 64)
+    with pytest.raises(UnknownHashError):
+        ItemHash("0123456789ABCDEF" * 4)  # hex but uppercase
+
+
+def test_cidv0_rejects_invalid_alphabet():
+    # 44-char strings starting with "Qm" must match base58btc.
+    with pytest.raises(UnknownHashError):
+        ItemHash("Qm" + "0" * 42)  # '0' not in base58btc
+    with pytest.raises(UnknownHashError):
+        ItemHash("Qm" + "O" * 42)  # 'O' not in base58btc
+    with pytest.raises(UnknownHashError):
+        ItemHash("Qm" + "l" * 42)  # 'l' not in base58btc
+
+
+def test_cidv1_rejects_invalid_alphabet():
+    # 59-char strings starting with "bafy" must match base32 (lowercase, no padding).
+    with pytest.raises(UnknownHashError):
+        ItemHash("bafy" + "1" * 55)  # '1' not in base32
+    with pytest.raises(UnknownHashError):
+        ItemHash("bafy" + "Z" * 55)  # uppercase not allowed


### PR DESCRIPTION
## Summary

Schema-level validation hardening from the recent security audit
(see `SECURITY_AUDIT.md` on main). One commit per issue, in dependency
order.

## Fixes

- **C1** — `ItemType.from_hash` / `ItemHash` now character-set-check
  storage hashes (hex), CIDv0 (base58btc) and CIDv1 (base32 lowercase).
  This closes the path-traversal vector where a 64-char string of
  `./../../...` was accepted as a storage hash and flowed into
  pyaleph's filesystem key.
- **M1** — replace `assert` statements in `check_item_hash` with
  explicit `ValueError` raises so Python's `-O` flag can't strip
  hash-algorithm validation.
- **M3** — `ForgetContent.hashes` / `ForgetContent.aggregates` capped at
  1000 entries each; `reason` capped at 1000 chars.
- **M5** — `NodeRequirements.address_regex` capped at 256 chars and
  validated to compile.
- **M6** — `MachineResources.vcpus` <= 256, `memory` <= 1 TiB (MiB),
  `seconds` <= ~10 years.
- **M7** — caps on `BaseExecutableContent.metadata`,
  `authorized_keys`, `variables`, `volumes`, `replaces`, and volume
  `comment` / `mount` / `name`.
- **M8** — `BaseMessage.channel` / `ChainRef.channel` capped at 128
  chars.
- **M9** — `StoreContent` switched from `extra=\"allow\"` to
  `extra=\"ignore\"` (accepts legacy extras without persisting them),
  `TrustedExecutionEnvironment` / `HostRequirements` switched to
  `extra=\"forbid\"`, `Subscription` keeps `extra=\"allow\"` but caps
  the entry count at 32.
- **L3** — `BaseContent.time` bounded to `0 <= t <= 9223372036` (year
  ~2262, below the float-precision cliff).

## Backwards compatibility

- The character-set tightening in C1 rejects some inputs that were
  previously accepted silently. All legitimate hashes (SHA-256 hex,
  real CIDs) continue to validate.
- M9 replaces `extra=\"allow\"` on StoreContent with `extra=\"ignore\"` —
  existing messages with extra keys keep parsing, but those keys are
  no longer preserved on the parsed model (they remain in the
  originating `item_content`).
- All other caps are generous enough to be transparent to realistic
  workloads.

## Test plan

- [x] `hatch -e testing run pytest` — 35 passing, 1 skipped, 4
  pre-existing network failures (unrelated 404 against
  `api.twentysix.testnet.network`).
- [x] New tests in `test_types.py` cover the C1 rejection paths:
  path-traversal string, uppercase hex, invalid CID alphabets.
- [ ] Downstream integration test in pyaleph (manual, post-merge).

## Not included

Issues C2, H1, H2 from the audit require coordinated signing / schema
changes across \`aleph-client\`, \`pyaleph\`, and wallets and are out of
scope for this PR. Other MEDIUM findings (M2, M4) and some LOW
findings (L1, L2, L4) also remain.