### PR TITLE
Validate character sets in ItemType.from_hash

### DIFF
--- a/aleph_message/models/item_hash.py
+++ b/aleph_message/models/item_hash.py
@@ -6,6 +6,14 @@ from pydantic_core import core_schema
 
 from ..exceptions import UnknownHashError
 
+# SHA-256 hex digest used as the `storage` item hash.
+_HEX_LOWER = frozenset("0123456789abcdef")
+# Base58btc excludes 0, O, I and l to avoid visually-ambiguous characters.
+_BASE58BTC = frozenset("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")
+# Base32 (RFC 4648, lowercase, no padding), the encoding used by the
+# `bafy` CIDv1 prefix.
+_BASE32_LOWER = frozenset("abcdefghijklmnopqrstuvwxyz234567")
+
 
 class ItemType(str, Enum):
     """Item storage options"""
@@ -18,14 +26,21 @@ class ItemType(str, Enum):
     @lru_cache
     def from_hash(cls, item_hash: str) -> "ItemType":
         # https://docs.ipfs.io/concepts/content-addressing/#identifier-formats
-        if item_hash.startswith("Qm") and 44 <= len(item_hash) <= 46:  # CIDv0
+        if (
+            item_hash.startswith("Qm")
+            and 44 <= len(item_hash) <= 46
+            and _BASE58BTC.issuperset(item_hash[2:])
+        ):
             return cls.ipfs
-        elif item_hash.startswith("bafy") and len(item_hash) == 59:  # CIDv1
+        if (
+            item_hash.startswith("bafy")
+            and len(item_hash) == 59
+            and _BASE32_LOWER.issuperset(item_hash[4:])
+        ):
             return cls.ipfs
-        elif len(item_hash) == 64:
+        if len(item_hash) == 64 and _HEX_LOWER.issuperset(item_hash):
             return cls.storage
-        else:
-            raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
+        raise UnknownHashError(f"Could not determine hash type: '{item_hash}'")
 
     @classmethod
     def is_storage(cls, item_hash: str):

--- a/aleph_message/tests/test_types.py
+++ b/aleph_message/tests/test_types.py
@@ -75,3 +75,31 @@ def test_bad_item_hashes():
     # UnknownHashError should be a ValueError
     with pytest.raises(ValueError):
         ItemHash("This is not a hash !")
+
+
+def test_storage_hash_rejects_non_hex():
+    # 64-char non-hex strings (previously accepted) must now be rejected.
+    with pytest.raises(UnknownHashError):
+        ItemHash(".//" + "../" * 12 + "root/.ssh/authorized_keys")  # path-traversal
+    with pytest.raises(UnknownHashError):
+        ItemHash("X" * 64)
+    with pytest.raises(UnknownHashError):
+        ItemHash("0123456789ABCDEF" * 4)  # hex but uppercase
+
+
+def test_cidv0_rejects_invalid_alphabet():
+    # 44-char strings starting with "Qm" must match base58btc.
+    with pytest.raises(UnknownHashError):
+        ItemHash("Qm" + "0" * 42)  # '0' not in base58btc
+    with pytest.raises(UnknownHashError):
+        ItemHash("Qm" + "O" * 42)  # 'O' not in base58btc
+    with pytest.raises(UnknownHashError):
+        ItemHash("Qm" + "l" * 42)  # 'l' not in base58btc
+
+
+def test_cidv1_rejects_invalid_alphabet():
+    # 59-char strings starting with "bafy" must match base32 (lowercase, no padding).
+    with pytest.raises(UnknownHashError):
+        ItemHash("bafy" + "1" * 55)  # '1' not in base32
+    with pytest.raises(UnknownHashError):
+        ItemHash("bafy" + "Z" * 55)  # uppercase not allowed


### PR DESCRIPTION
The length-only check accepted non-hash strings such as arbitrary 64-char text or uppercase hex. Require SHA-256 hex for storage hashes, base58btc for CIDv0, and base32 lowercase for CIDv1, and add tests for the rejected inputs.

## Test plan

- [x] `hatch -e testing run pytest` (unchanged — same 4 pre-existing network-flaky tests fail on main)