### PR TITLE
Bound and validate NodeRequirements.address_regex

### DIFF
--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from enum import Enum
 from typing import List, Literal, Optional, Union
 
@@ -8,6 +9,8 @@ from pydantic import ConfigDict, Field, field_validator
 from ...utils import Mebibytes
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
+
+MAX_ADDRESS_REGEX_LENGTH = 256
 
 
 class Subscription(HashableModel):
@@ -176,7 +179,9 @@ class InstanceEnvironment(HashableModel):
 class NodeRequirements(HashableModel):
     owner: Optional[str] = Field(default=None, description="Address of the node owner")
     address_regex: Optional[str] = Field(
-        default=None, description="Node address must match this regular expression"
+        default=None,
+        max_length=MAX_ADDRESS_REGEX_LENGTH,
+        description="Node address must match this regular expression",
     )
     node_hash: Optional[ItemHash] = Field(
         default=None, description="Hash of the compute resource node that must be used"
@@ -186,6 +191,16 @@ class NodeRequirements(HashableModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_validator("address_regex")
+    def check_address_regex_compiles(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        try:
+            re.compile(v)
+        except re.error as exc:
+            raise ValueError(f"Invalid regular expression: {exc}") from exc
+        return v
 
 
 class HostRequirements(HashableModel):

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -32,7 +32,12 @@ from aleph_message.models import (
     create_new_message,
     parse_message,
 )
-from aleph_message.models.execution.environment import AMDSEVPolicy, HypervisorType
+from aleph_message.models.execution.environment import (
+    MAX_ADDRESS_REGEX_LENGTH,
+    AMDSEVPolicy,
+    HypervisorType,
+    NodeRequirements,
+)
 from aleph_message.tests.download_messages import MESSAGES_STORAGE_PATH
 
 console = Console(color_system="windows")
@@ -666,3 +671,23 @@ def test_store_message_backward_compatibility_no_payment():
     message = create_new_message(message_dict, factory=StoreMessage)
     assert isinstance(message, StoreMessage)
     assert message.content.payment is None  # Defaults to None (hold tier behavior)
+
+
+def test_address_regex_valid():
+    NodeRequirements(address_regex="^0x[a-f0-9]{40}$")
+
+
+def test_address_regex_invalid_raises():
+    with pytest.raises(ValidationError):
+        NodeRequirements(address_regex="[unclosed")
+
+
+def test_address_regex_length_boundary():
+    # Exactly MAX_ADDRESS_REGEX_LENGTH is allowed; one over is rejected.
+    NodeRequirements(address_regex="a" * MAX_ADDRESS_REGEX_LENGTH)
+    with pytest.raises(ValidationError):
+        NodeRequirements(address_regex="a" * (MAX_ADDRESS_REGEX_LENGTH + 1))
+
+
+def test_address_regex_none_passes():
+    assert NodeRequirements(address_regex=None).address_regex is None


### PR DESCRIPTION
Cap the field at 256 characters and reject values that don't compile as Python regular expressions. Catches malformed patterns at schema-validation time rather than at match time.

## Test plan

- [x] `hatch -e testing run pytest` (unchanged — same 4 pre-existing network-flaky tests fail on main)