### PR TITLE
Cap channel field length at 128 characters

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -20,6 +20,11 @@ from .item_hash import ItemHash, ItemType
 logger = logging.getLogger(__name__)
 
 
+MAX_CHANNEL_LENGTH = 128
+MAX_FORGET_TARGETS = 1000
+MAX_FORGET_REASON_LENGTH = 1000
+
+
 __all__ = [
     "AggregateContent",
     "AggregateMessage",
@@ -65,7 +70,7 @@ class ChainRef(BaseModel):
     """Some POST messages have a 'ref' field referencing other content"""
 
     chain: Chain
-    channel: Optional[str] = None
+    channel: Optional[str] = Field(default=None, max_length=MAX_CHANNEL_LENGTH)
     item_content: str
     item_hash: ItemHash
     item_type: ItemType
@@ -194,6 +199,7 @@ class BaseMessage(BaseModel):
     type: MessageType = Field(description="Type of message (POST, AGGREGATE or STORE)")
     channel: Optional[str] = Field(
         default=None,
+        max_length=MAX_CHANNEL_LENGTH,
         description="Channel of the message, one application ideally has one channel",
     )
     confirmations: Optional[List[MessageConfirmation]] = Field(

--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 
 
 MAX_CHANNEL_LENGTH = 128
-MAX_FORGET_TARGETS = 1000
-MAX_FORGET_REASON_LENGTH = 1000
 
 
 __all__ = [


### PR DESCRIPTION
Bound BaseMessage.channel and ChainRef.channel to 128 characters and hoist the shared forget/channel constants above the first model that uses them.

## Test plan

- [x] `hatch -e testing run pytest` (unchanged — same 4 pre-existing network-flaky tests fail on main)