### PR TITLE
Tighten extra-field policies on loose models

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -165,7 +165,11 @@ class StoreContent(BaseContent):
             )
         return v
 
-    model_config = ConfigDict(extra="allow")
+    # `extra="ignore"` drops unknown fields silently rather than preserving
+    # them (previous `extra="allow"`) or rejecting the message outright
+    # (`extra="forbid"`). Messages in the wild may contain legacy extras;
+    # "ignore" keeps them accepted without widening the persistence surface.
+    model_config = ConfigDict(extra="ignore")
 
 
 MAX_FORGET_TARGETS = 1000

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -4,17 +4,31 @@ import re
 from enum import Enum
 from typing import List, Literal, Optional, Union
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from ...utils import Mebibytes
 from ..abstract import HashableModel
 from ..item_hash import ItemHash
 
 MAX_ADDRESS_REGEX_LENGTH = 256
+MAX_SUBSCRIPTION_ENTRIES = 32
 
 
 class Subscription(HashableModel):
     """A subscription is used to trigger a program in response to a FunctionTrigger."""
+
+    # Subscriptions are user-defined filter criteria; the model intentionally
+    # accepts arbitrary keys. Cap the number of entries so a subscription
+    # object can't be padded with hundreds of keys.
+    @model_validator(mode="after")
+    def check_subscription_size(self) -> "Subscription":
+        extra = self.__pydantic_extra__ or {}
+        if len(extra) > MAX_SUBSCRIPTION_ENTRIES:
+            raise ValueError(
+                f"Subscription has {len(extra)} entries, "
+                f"maximum allowed is {MAX_SUBSCRIPTION_ENTRIES}"
+            )
+        return self
 
     model_config = ConfigDict(extra="allow")
 
@@ -159,7 +173,7 @@ class TrustedExecutionEnvironment(HashableModel):
         description="Policy of the TEE. Default value is 0x01 for SEV without debugging.",
     )
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")
 
 
 class InstanceEnvironment(HashableModel):
@@ -225,4 +239,4 @@ class HostRequirements(HashableModel):
     def gpu_requirements(self):
         return self.gpu or []
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
- StoreContent: extra=allow -> extra=ignore. Accepts legacy messages with extra keys but stops silently persisting them on the parsed model.
- TrustedExecutionEnvironment and HostRequirements: extra=forbid. Small, fixed schemas.
- Subscription keeps extra=allow (arbitrary filters are its purpose) but caps entry count at 32.

## Test plan

- [x] `hatch -e testing run pytest` (unchanged — same 4 pre-existing network-flaky tests fail on main)