### PR TITLE
Bound BaseContent.time to a reasonable range

### DIFF
--- a/aleph_message/models/abstract.py
+++ b/aleph_message/models/abstract.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
+# Unix timestamp upper bound (year 2262). Well below the float-precision
+# cliff at 2**53 while still leaving headroom for any realistic message.
+MAX_CONTENT_TIME = 9_223_372_036.0
 
 
 def hashable(obj):
@@ -22,6 +26,6 @@ class BaseContent(BaseModel):
     """Base template for message content"""
 
     address: str
-    time: float
+    time: float = Field(ge=0, le=MAX_CONTENT_TIME)
 
     model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
Require time to be non-negative and below year ~2262 (9223372036, comfortably within float precision). Matches the constraints already enforced downstream in pyaleph's pending-message schema.

## Test plan

- [x] `hatch -e testing run pytest` (unchanged — same 4 pre-existing network-flaky tests fail on main)