### PR TITLE
Skip network-dependent tests by default

### DIFF
--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -45,6 +45,7 @@ HASHES_TO_IGNORE = (
 )
 
 
+@pytest.mark.network
 def test_message_response_aggregate():
     path = (
         "/api/v0/messages.json?hashes=4955df177e225e0380d27283963c7d798e841ebe0b53abc44373ade2860eb458"
@@ -59,6 +60,7 @@ def test_message_response_aggregate():
     assert response
 
 
+@pytest.mark.network
 def test_message_response_post():
     path = (
         "/api/v0/messages.json?hashes=05c0c72091f6b3ea01173baf1a735974c81abf29be729d088771ed32cb6af108"
@@ -70,6 +72,7 @@ def test_message_response_post():
     assert response
 
 
+@pytest.mark.network
 def test_message_response_store():
     path = (
         "/api/v0/messages.json?hashes=37e35fa3842a7c2f610cc423a209aedd6db3d5fd5c2507d23140b2d704a95fe5"
@@ -81,6 +84,7 @@ def test_message_response_store():
     assert response
 
 
+@pytest.mark.network
 def test_messages_last_page():
     path = "/api/v0/messages.json"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,12 @@ dependencies = [
 
 # XXX see https://github.com/aleph-im/pyaleph/blob/main/.github/workflows/pyaleph-ci.yml
 [tool.hatch.envs.testing.scripts]
-test = "pytest -v {args:.}"
-test-cov = "pytest -v --cov {args:.}"
+# Default test runs skip tests marked `network` (which hit a live testnet
+# node) so CI does not depend on that endpoint's availability. Run
+# `hatch -e testing run test-network` to exercise them explicitly.
+test = "pytest -v -m 'not network' {args:.}"
+test-cov = "pytest -v -m 'not network' --cov {args:.}"
+test-network = "pytest -v -m network {args:.}"
 cov-report = [
   "- coverage combine",
   "coverage report",
@@ -132,9 +136,10 @@ git-only = [
 ]
 default-ignore = true
 
-[tool.pytest]
+[tool.pytest.ini_options]
 markers = [
   "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+  "network: marks tests that require network access to a live Aleph node (deselect with '-m \"not network\"')",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

Four tests in \`test_models.py\` hit a live testnet API
(\`api.twentysix.testnet.network\`) and have been flaking CI on every
PR — the endpoint currently returns non-JSON for three of the queries
and a 404 for \`test_messages_last_page\`.

This change stops PR CI from depending on that endpoint while keeping
the tests runnable on demand:

- Mark the four tests with \`@pytest.mark.network\`.
- Move pytest config from \`[tool.pytest]\` (silently ignored by
  pytest 8) to \`[tool.pytest.ini_options]\`. This also silences the
  existing \`PytestUnknownMarkWarning\` for \`@pytest.mark.slow\`.
- Default \`hatch -e testing run test\` / \`test-cov\` now pass
  \`-m "not network"\`. A new \`test-network\` script runs only the
  marked tests, for manual or nightly invocation.

## Test plan

- [x] \`hatch -e testing run test\` → 32 passed, 1 skipped, 4 deselected.
- [x] \`hatch -e testing run test-network --collect-only\` collects the
  four network tests and deselects the other 33.
- [x] \`hatch -e linting run all\` passes (black / ruff / isort / mypy /
  yamlfix / pyproject-fmt / check-sdist).
- [ ] Post-merge: CI on the nine open feature branches should drop
  from \"4 failed\" to green once rebased onto main.