### PR TITLE
Make ALEPH_API_SERVER configurable (env var + Actions variable)

### DIFF
--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -20,6 +20,12 @@ jobs:
         os: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
 
+    env:
+      # Allow redirecting the tests to another Aleph node by setting the
+      # ALEPH_API_SERVER repository variable. Defaults to the long-standing
+      # public testnet URL when the variable is not set.
+      ALEPH_API_SERVER: ${{ vars.ALEPH_API_SERVER || 'https://api.twentysix.testnet.network' }}
+
     steps:
       - uses: actions/checkout@v3
 
@@ -36,6 +42,9 @@ jobs:
       - run: |
           python3 -m venv /tmp/venv
           /tmp/venv/bin/python -m pip install --upgrade pip hatch coverage
+
+      - name: Show test API server
+        run: echo "Running tests against ALEPH_API_SERVER=$ALEPH_API_SERVER"
 
       - run: /tmp/venv/bin/hatch run testing:cov
 

--- a/aleph_message/tests/download_messages.py
+++ b/aleph_message/tests/download_messages.py
@@ -1,10 +1,13 @@
 import json
+import os
 from os import makedirs
 from os.path import abspath, join
 
 import requests
 
-ALEPH_API_SERVER = "https://api.twentysix.testnet.network"
+ALEPH_API_SERVER = os.environ.get(
+    "ALEPH_API_SERVER", "https://api.twentysix.testnet.network"
+)
 MESSAGES_STORAGE_PATH: str = abspath(join(__file__, "../test_messages"))
 
 

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -37,7 +37,12 @@ from aleph_message.tests.download_messages import MESSAGES_STORAGE_PATH
 
 console = Console(color_system="windows")
 
-ALEPH_API_SERVER = "https://api.twentysix.testnet.network"
+# Override with the ALEPH_API_SERVER environment variable to run the
+# network tests against a different node (e.g. while the default
+# testnet endpoint is under maintenance).
+ALEPH_API_SERVER = os.environ.get(
+    "ALEPH_API_SERVER", "https://api.twentysix.testnet.network"
+)
 
 HASHES_TO_IGNORE = (
     "2fe5470ebcc5b6168b778ca3baadfd1618dc3acdb0690478760d21ff24b03164",


### PR DESCRIPTION
## Summary

The API server used by the network tests was hardcoded to
`https://api.twentysix.testnet.network`. This PR makes it configurable
end-to-end:

- **Code**: `ALEPH_API_SERVER` now reads from an environment variable
  and falls back to the current default when unset.
- **CI**: the `Tests` workflow pulls the value from
  `vars.ALEPH_API_SERVER` (a repository variable), falling back to
  the same default. A dedicated step echoes the resolved value near
  the top of each job so the target endpoint is visible in the log.

Default behaviour is unchanged.

## Usage

Local override:

```bash
ALEPH_API_SERVER=https://api.other-testnet.example hatch -e testing run test
```

CI override: set the `ALEPH_API_SERVER` repository variable in
**Settings → Secrets and variables → Actions → Variables**. No code
change needed; the next workflow run will use the new value, and the
"Show test API server" step will print it at the top of each job.

## Test plan

- [x] `hatch -e testing run test` with no override: behaves exactly as
  before.
- [x] `ALEPH_API_SERVER=http://127.0.0.1:1 hatch …`: confirms the
  override is consulted (tests hit the overridden host and fail with
  `Connection refused`).
- [x] `hatch -e linting run all` passes.
- [ ] After merge: set `vars.ALEPH_API_SERVER` at the repo level to
  redirect CI onto a healthy testnet while the default endpoint is
  under maintenance.