### PR TITLE
Derive __version__ from installed package metadata

### DIFF
--- a/aleph_message/__init__.py
+++ b/aleph_message/__init__.py
@@ -1,4 +1,10 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .models import MessagesResponse, parse_message
 
 __all__ = ["parse_message", "MessagesResponse"]
-__version__ = "0.6.0"
+
+try:
+    __version__ = version("aleph-message")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
## Summary
- Replace the hardcoded `__version__` literal in `aleph_message/__init__.py` with an `importlib.metadata.version("aleph-message")` lookup.
- Makes the git tag the single source of truth for the package version (the wheel version is already dynamic via `hatch-vcs`); no more manual bump step during releases.
- Falls back to `"0.0.0+unknown"` if the package isn't installed (e.g. running from a raw source tree without `pip install -e .`).

## Test plan
- [x] `pip install -e . && python -c "import aleph_message; print(aleph_message.__version__)"` prints the hatch-vcs-derived version
- [ ] CI passes
- [ ] After merge, tag `v1.1.1` on `main` and confirm the published wheel reports `1.1.1`