### PR TITLE
fix(instance): drop node_hash requirement for credit payments

### DIFF
--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -42,15 +42,20 @@ class InstanceContent(BaseExecutableContent):
     @model_validator(mode="after")
     def check_requirements(self) -> Self:
         if self.requirements:
-            if (
-                self.payment and (self.payment.is_stream or self.payment.is_credit)
-            ) and (not self.requirements.node or not self.requirements.node.node_hash):
-                raise ValueError(
-                    "Node hash assignment is needed for PAYG or Credit payments"
-                )
-            # GPU filter only supported for QEmu instances with node_hash assigned
+            # Streamed (PAYG) payments must target a specific node. Credit
+            # payments are billed independently of the host, so they no longer
+            # need to pin a node.
+            if (self.payment and self.payment.is_stream) and (
+                not self.requirements.node or not self.requirements.node.node_hash
+            ):
+                raise ValueError("Node hash assignment is needed for PAYG payments")
+            # GPU filter only supported for QEmu instances. The GPU host must be
+            # pinned with a node_hash, except for credit payments which are not
+            # tied to a specific node.
             if self.requirements.gpu:
-                if not self.requirements.node or not self.requirements.node.node_hash:
+                if not (self.payment and self.payment.is_credit) and (
+                    not self.requirements.node or not self.requirements.node.node_hash
+                ):
                     raise ValueError("Node hash assignment is needed for GPU support")
 
                 if (

--- a/aleph_message/tests/test_models.py
+++ b/aleph_message/tests/test_models.py
@@ -294,17 +294,19 @@ def test_validation_on_payg_payment_options():
 
         error_msg = e.errors()[0]["msg"]
         assert (
-            "Node hash assignment is needed for PAYG or Credit payments" in error_msg
+            "Node hash assignment is needed for PAYG payments" in error_msg
         )  # Ignore "Value error, ..."
 
 
 def test_validation_on_credits_payment_options():
-    """Ensure that a node_hash option is required for credit payments."""
+    """Ensure that credit payments do NOT require a node_hash, even with a GPU."""
     path = Path(__file__).parent / "messages/instance_gpu_machine.json"
     message_dict = json.loads(path.read_text())
-    # Patch the gpu field with some info
     message_dict["content"]["payment"]["type"] = "credit"
     message_dict["content"]["payment"]["receiver"] = None
+
+    # A credit GPU instance is accepted without pinning a node.
+    message_dict["content"]["requirements"]["node"] = None
     message = create_new_message(message_dict, factory=InstanceMessage)
 
     assert isinstance(message, InstanceMessage)
@@ -312,8 +314,10 @@ def test_validation_on_credits_payment_options():
     assert message.content.payment
     assert message.content.payment.type == PaymentType.credit
     assert message.content.environment.hypervisor == HypervisorType.qemu
+    assert message.content.requirements.node is None
+    assert message.content.requirements.gpu
 
-    # Remove gpu field with some info
+    # A credit instance without a GPU is likewise accepted without a node.
     message_dict["content"]["requirements"]["gpu"] = None
     message = create_new_message(message_dict, factory=InstanceMessage)
 
@@ -321,20 +325,8 @@ def test_validation_on_credits_payment_options():
     assert hash(message.content)
     assert message.content.payment
     assert message.content.payment.type == PaymentType.credit
-    assert message.content.environment.hypervisor == HypervisorType.qemu
+    assert message.content.requirements.node is None
     assert message.content.requirements.gpu is None
-
-    message_dict["content"]["requirements"]["node"] = None
-    try:
-        _ = create_new_message(message_dict, factory=InstanceMessage)
-        raise AssertionError("An exception should have been raised before this point.")
-    except ValidationError as e:
-        assert e.errors()[0]["loc"] in [("content",), ("content", "__root__")]
-
-        error_msg = e.errors()[0]["msg"]
-        assert (
-            "Node hash assignment is needed for PAYG or Credit payments" in error_msg
-        )  # Ignore "Value error, ..."
 
 
 def test_message_machine_port_mapping():


### PR DESCRIPTION
## Problem

Credit-based VMs are rejected by `InstanceContent` validation unless they pin a specific compute resource node (`requirements.node.node_hash`). This is no longer accurate: credit billing is independent of the host, so credit VMs (including GPU instances) should not be forced to target a node.

In practice this surfaces as an opaque `HTTP 422 InvalidMessageFormat` to clients. For example, creating a credit GPU instance without a CRN hash trips both the `is_credit` branch of the PAYG/Credit check and the GPU `node_hash` check.

## Change

- The PAYG/Credit node-hash requirement now applies to **streamed (PAYG) payments only**. Credit payments no longer require a `node_hash`. The error message becomes `"Node hash assignment is needed for PAYG payments"`.
- GPU validation no longer requires a `node_hash` when the instance is paid with **credits**. PAYG (and hold) GPU instances still require one, and the QEmu-hypervisor restriction is unchanged.

## Behavior matrix

| Payment | GPU | node_hash required? |
|---------|-----|---------------------|
| PAYG (superfluid) | any | yes (unchanged) |
| credit | yes | **no** (was: yes) |
| credit | no | **no** (was: yes) |
| hold | yes | yes (unchanged) |

## Tests

- `test_validation_on_payg_payment_options`: asserts the updated PAYG-only error message.
- `test_validation_on_credits_payment_options`: rewritten to assert credit instances (with and without GPU) are accepted **without** a `node_hash`.
- `test_validation_on_gpu_payment_options` (hold + GPU) still requires a node_hash, unchanged.

Full `test_models.py` suite passes locally (42 passed, 1 skipped).