### PR TITLE
Add V-PROGRAM message type and SEV-SNP trusted execution mode

### DIFF
--- a/aleph_message/models/__init__.py
+++ b/aleph_message/models/__init__.py
@@ -26,6 +26,7 @@ from .base import Chain, HashType, MessageType
 from .execution.base import MachineType, Payment, PaymentType
 from .execution.instance import InstanceContent
 from .execution.program import ProgramContent
+from .execution.vprogram import VerifiableProgramContent
 from .item_hash import ItemHash, ItemType
 
 logger = logging.getLogger(__name__)
@@ -64,6 +65,8 @@ __all__ = [
     "ProgramMessage",
     "StoreContent",
     "StoreMessage",
+    "VerifiableProgramContent",
+    "VerifiableProgramMessage",
 ]
 
 
@@ -403,12 +406,35 @@ class InstanceMessage(BaseMessage):
     forgotten_by: Optional[List[str]] = None
 
 
+class VerifiableProgramMessage(BaseMessage):
+    type: Literal[MessageType.v_program]
+    content: VerifiableProgramContent
+    forgotten_by: Optional[List[str]] = None
+
+    @field_validator("content")
+    def check_content(cls, v, values):
+        """Ensure that the content of the message is correctly formatted."""
+        item_type = values.data.get("item_type")
+        if item_type == ItemType.inline:
+            # Ensure that the content correct JSON
+            item_content = json.loads(values.data.get("item_content"))
+            # Ensure that the content matches the expected structure
+            if v.model_dump(exclude_none=True) != item_content:
+                logger.warning(
+                    "Content and item_content differ for message %s",
+                    values.data["item_hash"],
+                )
+                raise ValueError("Content and item_content differ")
+        return v
+
+
 AlephMessage: TypeAlias = Union[
     PostMessage,
     AggregateMessage,
     StoreMessage,
     ProgramMessage,
     InstanceMessage,
+    VerifiableProgramMessage,
     ForgetMessage,
 ]
 
@@ -423,11 +449,16 @@ message_classes: List[AlephMessageType] = [
     StoreMessage,
     ProgramMessage,
     InstanceMessage,
+    VerifiableProgramMessage,
     ForgetMessage,
 ]
 
-ExecutableContent: TypeAlias = Union[InstanceContent, ProgramContent]
-ExecutableMessage: TypeAlias = Union[InstanceMessage, ProgramMessage]
+ExecutableContent: TypeAlias = Union[
+    InstanceContent, ProgramContent, VerifiableProgramContent
+]
+ExecutableMessage: TypeAlias = Union[
+    InstanceMessage, ProgramMessage, VerifiableProgramMessage
+]
 
 
 def parse_message(message_dict: Dict) -> AlephMessage:

--- a/aleph_message/models/base.py
+++ b/aleph_message/models/base.py
@@ -53,4 +53,5 @@ class MessageType(str, Enum):
     store = "STORE"
     program = "PROGRAM"
     instance = "INSTANCE"
+    v_program = "V-PROGRAM"
     forget = "FORGET"

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -162,6 +162,73 @@ class AMDSEVPolicy(int, Enum):
     SEV = 0b100000  # The guest must not be transmitted to another platform that is not SEV capable
 
 
+# SEV-SNP guest policy (64-bit). Bit 17 is reserved and must be 1; 0x30000
+# also sets bit 16 (SMT allowed), the recommended default.
+SNP_POLICY_RESERVED_BIT_17 = 1 << 17
+DEFAULT_SNP_POLICY = 0x30000
+MAX_VCPU_TYPE_LENGTH = 64
+
+
+def validate_snp_policy(policy: int) -> None:
+    """Raise ValueError if the value is not a plausible SEV-SNP guest policy."""
+    if not policy & SNP_POLICY_RESERVED_BIT_17:
+        raise ValueError(
+            "SEV-SNP guest policy must have reserved bit 17 set "
+            f"(e.g. {DEFAULT_SNP_POLICY:#x}); got {policy:#x}. "
+            "Note that SEV policy bit semantics do not apply to SEV-SNP."
+        )
+
+
+class TeePlatform(str, Enum):
+    """TEE platforms with a defined launch-measurement semantics.
+
+    Grows over protocol upgrades (e.g. "tdx" with MRTD digests). Unknown
+    platforms are schema-invalid: nothing unverifiable gets network blessing.
+    """
+
+    sev_snp = "sev_snp"
+
+
+# Expected hex length of a launch digest, per platform.
+# sev_snp: 48-byte SHA-384 launch digest.
+_DIGEST_HEX_LENGTHS = {TeePlatform.sev_snp: 96}
+
+
+class LaunchMeasurement(HashableModel):
+    """Supervisor-opaque verification annotation, validated by the CCN.
+
+    Declares the launch digest a verifier should expect. Multiple entries
+    (one per vcpu_type) keep a message verifiable across a mixed CPU fleet.
+    """
+
+    platform: TeePlatform
+    digest: str = Field(
+        pattern=r"^[0-9a-f]+$",
+        max_length=128,
+        description="Expected launch digest, lowercase hex; length is platform-defined",
+    )
+    vcpu_type: Optional[str] = Field(
+        default=None,
+        max_length=MAX_VCPU_TYPE_LENGTH,
+        description=(
+            "QEMU CPU model this digest was computed for (e.g. 'EPYC-v4'). "
+            "Required by direct-boot measurement recipes, absent for igvm bundles."
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def check_digest_length(self) -> "LaunchMeasurement":
+        expected = _DIGEST_HEX_LENGTHS[self.platform]
+        if len(self.digest) != expected:
+            raise ValueError(
+                f"{self.platform.value} digest must be {expected} hex characters, "
+                f"got {len(self.digest)}"
+            )
+        return self
+
+
 class TrustedExecutionEnvironment(HashableModel):
     """Trusted Execution Environment properties."""
 

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -167,11 +167,18 @@ class AMDSEVPolicy(int, Enum):
 SNP_POLICY_RESERVED_BIT_17 = 1 << 17
 DEFAULT_SNP_POLICY = 0x30000
 MAX_VCPU_TYPE_LENGTH = 64
+# Protocol-wide cap on the number of launch measurements a single TEE
+# declaration may carry (one per vcpu_type in the mixed-fleet case).
+MAX_MEASUREMENTS = 16
 
 
 def validate_snp_policy(policy: int) -> None:
     """Raise ValueError if the value is not a plausible SEV-SNP guest policy."""
     policy_int = int(policy)
+    if not 0 <= policy_int < 1 << 64:
+        raise ValueError(
+            f"SEV-SNP guest policy must be an unsigned 64-bit integer; got {policy_int:#x}"
+        )
     if not policy_int & SNP_POLICY_RESERVED_BIT_17:
         raise ValueError(
             "SEV-SNP guest policy must have reserved bit 17 set "
@@ -221,7 +228,11 @@ class LaunchMeasurement(HashableModel):
 
     @model_validator(mode="after")
     def check_digest_length(self) -> "LaunchMeasurement":
-        expected = _DIGEST_HEX_LENGTHS[self.platform]
+        expected = _DIGEST_HEX_LENGTHS.get(self.platform)
+        if expected is None:
+            raise ValueError(
+                f"no digest length defined for platform {self.platform.value}"
+            )
         if len(self.digest) != expected:
             raise ValueError(
                 f"{self.platform.value} digest must be {expected} hex characters, "
@@ -262,7 +273,7 @@ class TrustedExecutionEnvironment(HashableModel):
     )
     measurements: Optional[List[LaunchMeasurement]] = Field(
         default=None,
-        max_length=16,
+        max_length=MAX_MEASUREMENTS,
         description="Expected launch digests (sev_snp mode only); CCN-validated",
     )
     attestation_port: Optional[int] = Field(

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -171,10 +171,11 @@ MAX_VCPU_TYPE_LENGTH = 64
 
 def validate_snp_policy(policy: int) -> None:
     """Raise ValueError if the value is not a plausible SEV-SNP guest policy."""
-    if not policy & SNP_POLICY_RESERVED_BIT_17:
+    policy_int = int(policy)
+    if not policy_int & SNP_POLICY_RESERVED_BIT_17:
         raise ValueError(
             "SEV-SNP guest policy must have reserved bit 17 set "
-            f"(e.g. {DEFAULT_SNP_POLICY:#x}); got {policy:#x}. "
+            f"(e.g. {DEFAULT_SNP_POLICY:#x}); got {policy_int:#x}. "
             "Note that SEV policy bit semantics do not apply to SEV-SNP."
         )
 
@@ -230,17 +231,76 @@ class LaunchMeasurement(HashableModel):
 
 
 class TrustedExecutionEnvironment(HashableModel):
-    """Trusted Execution Environment properties."""
+    """Trusted Execution Environment properties.
+
+    Two modes coexist:
+    - mode None or "sev" (legacy): AMD SEV/SEV-ES with the CRN-mediated
+      launch-secret flow; `firmware` references the confidential OVMF and
+      `policy` uses AMD SEV bit semantics (AMDSEVPolicy).
+    - mode "sev_snp": measured boot from a runtime bundle with direct
+      client-to-guest attestation; `policy` uses SEV-SNP 64-bit semantics
+      and `measurements` carry the expected launch digests.
+    """
 
     firmware: Optional[ItemHash] = Field(
-        default=None, description="Confidential OVMF firmware to use"
+        default=None, description="Confidential OVMF firmware to use (SEV mode only)"
     )
     policy: int = Field(
         default=AMDSEVPolicy.NO_DBG,
-        description="Policy of the TEE. Default value is 0x01 for SEV without debugging.",
+        description=(
+            "Policy of the TEE. SEV bit semantics in SEV mode (default 0x01, "
+            "no debugging); SEV-SNP 64-bit guest policy in sev_snp mode."
+        ),
+    )
+    mode: Optional[Literal["sev", "sev_snp"]] = Field(
+        default=None,
+        description="TEE mode; None means legacy SEV (kept for wire stability)",
+    )
+    runtime: Optional[ItemHash] = Field(
+        default=None,
+        description="Measured runtime bundle store message (sev_snp mode only)",
+    )
+    measurements: Optional[List[LaunchMeasurement]] = Field(
+        default=None,
+        max_length=16,
+        description="Expected launch digests (sev_snp mode only); CCN-validated",
+    )
+    attestation_port: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=65535,
+        description=(
+            "In-guest attestation port (sev_snp mode only); None means the "
+            "runtime bundle default (8443)"
+        ),
     )
 
     model_config = ConfigDict(extra="forbid")
+
+    @property
+    def is_snp(self) -> bool:
+        return self.mode == "sev_snp"
+
+    @model_validator(mode="after")
+    def check_mode_consistency(self) -> "TrustedExecutionEnvironment":
+        if self.is_snp:
+            if self.firmware is not None:
+                raise ValueError(
+                    "firmware belongs to the SEV flow and must not be set in "
+                    "sev_snp mode; use runtime instead"
+                )
+            if self.runtime is None:
+                raise ValueError("sev_snp mode requires runtime")
+            if not self.measurements:
+                raise ValueError("sev_snp mode requires measurements")
+            validate_snp_policy(self.policy)
+        else:
+            for field_name in ("runtime", "measurements", "attestation_port"):
+                if getattr(self, field_name) is not None:
+                    raise ValueError(
+                        f"{field_name} is only valid in sev_snp mode"
+                    )
+        return self
 
 
 class InstanceEnvironment(HashableModel):

--- a/aleph_message/models/execution/environment.py
+++ b/aleph_message/models/execution/environment.py
@@ -297,9 +297,7 @@ class TrustedExecutionEnvironment(HashableModel):
         else:
             for field_name in ("runtime", "measurements", "attestation_port"):
                 if getattr(self, field_name) is not None:
-                    raise ValueError(
-                        f"{field_name} is only valid in sev_snp mode"
-                    )
+                    raise ValueError(f"{field_name} is only valid in sev_snp mode")
         return self
 
 

--- a/aleph_message/models/execution/instance.py
+++ b/aleph_message/models/execution/instance.py
@@ -80,3 +80,16 @@ class InstanceContent(BaseExecutableContent):
                     )
 
         return self
+
+    @model_validator(mode="after")
+    def check_snp_payment(self) -> Self:
+        # SEV-SNP confidential instances are credit-only (see the confidential
+        # VM protocol design, aleph-vm docs/plans/2026-07-08).
+        trusted_execution = self.environment.trusted_execution
+        if trusted_execution is not None and trusted_execution.is_snp:
+            if not (self.payment and self.payment.is_credit):
+                raise ValueError(
+                    "SEV-SNP confidential instances are credit-only: "
+                    "holder-tier and PAYG stream payments are not supported"
+                )
+        return self

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -25,18 +25,59 @@ from .environment import (
 MAX_RUNTIME_COMMENT_LENGTH = 1024
 # sha256 dm-verity root hash, as printed by veritysetup format
 VERITY_ROOTHASH_PATTERN = r"^[0-9a-f]{64}$"
+MAX_ATTESTATION_PROTOCOLS = 8
+# Namespaced protocol identifier, e.g. "aleph.ra-tls" or "ietf.tls-attest"
+ATTESTATION_PROTOCOL_PATTERN = r"^[a-z0-9][a-z0-9-]*(\.[a-z0-9][a-z0-9-]*)+$"
+MAX_ATTESTATION_PROTOCOL_LENGTH = 64
 
 
 class ConfidentialRuntime(HashableModel):
-    """The measured platform: a store object bundling the manifest, OVMF,
-    kernel, initrd, and the dm-verity platform rootfs with its hash tree.
+    """The measured platform: a store message holding the runtime manifest,
+    which pins the OVMF, kernel, initrd and dm-verity platform rootfs (plus
+    its hash tree) by content hash, and declares the cmdline template, boot
+    format and attestation protocols the runtime implements.
 
     There is deliberately no use_latest: the measurements in the message pin
-    exact artifacts, so the reference must be immutable.
+    exact artifacts, so the reference must be immutable (resolved as an exact
+    item hash, never through file tags).
     """
 
-    ref: ItemHash = Field(description="Store message of the measured runtime bundle")
+    ref: ItemHash = Field(description="Store message of the runtime manifest")
     comment: str = Field(default="", max_length=MAX_RUNTIME_COMMENT_LENGTH)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class AttestationProtocol(HashableModel):
+    """One mechanism a client can use to obtain and channel-bind TEE evidence
+    from the running VM, e.g. RA-TLS certificate embedding, IETF attested TLS,
+    or an on-demand evidence endpoint.
+
+    The runtime manifest is the authoritative list of protocols the runtime
+    implements; the message carries this declared copy so clients and CCNs can
+    fail fast without fetching the manifest (checked redundancy, like launch
+    measurements). Protocol identifiers are an open, namespaced string space:
+    known values live in the runtime registry, not in this schema.
+    """
+
+    protocol: str = Field(
+        pattern=ATTESTATION_PROTOCOL_PATTERN,
+        max_length=MAX_ATTESTATION_PROTOCOL_LENGTH,
+        description="Namespaced protocol identifier, e.g. aleph.ra-tls",
+    )
+    version: int = Field(
+        ge=1, description="Protocol version implemented by the runtime"
+    )
+    port: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=65535,
+        description=(
+            "In-guest port serving this protocol; None means the runtime "
+            "manifest's declared default. Plumbed through the measured "
+            "cmdline; the agent auto-maps a host port for IPv4 clients."
+        ),
+    )
 
     model_config = ConfigDict(extra="forbid")
 
@@ -119,13 +160,12 @@ class VerifiableProgramContent(BaseExecutableContent):
     verification: TeeVerification = Field(
         description="TEE launch config and expected launch measurements"
     )
-    attestation_port: Optional[int] = Field(
-        default=None,
-        ge=1,
-        le=65535,
+    attestation: List[AttestationProtocol] = Field(
+        min_length=1,
+        max_length=MAX_ATTESTATION_PROTOCOLS,
         description=(
-            "In-guest attestation port; None means the runtime bundle's "
-            "declared default (8443). Plumbed through the measured cmdline."
+            "Attestation protocols the runtime exposes; a declared copy of "
+            "the runtime manifest entries"
         ),
     )
 

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -6,7 +6,7 @@ Design: aleph-vm docs/plans/2026-07-08-confidential-vm-protocol-design.md
 
 from __future__ import annotations
 
-from typing import List, Literal, Optional
+from typing import List, Literal
 
 from pydantic import ConfigDict, Field, model_validator
 from typing_extensions import Self
@@ -25,13 +25,12 @@ from .environment import (
 MAX_RUNTIME_COMMENT_LENGTH = 1024
 # sha256 dm-verity root hash, as printed by veritysetup format
 VERITY_ROOTHASH_PATTERN = r"^[0-9a-f]{64}$"
-MAX_ATTESTATION_PROTOCOLS = 8
-# Namespaced protocol identifier, e.g. "aleph.ra-tls" or "ietf.tls-attest"
-ATTESTATION_PROTOCOL_PATTERN = r"^[a-z0-9][a-z0-9-]*(\.[a-z0-9][a-z0-9-]*)+$"
-MAX_ATTESTATION_PROTOCOL_LENGTH = 64
+# Bounded by the kernel cmdline budget: each roothash costs ~65 bytes in the
+# measured verified_volumes= slot.
+MAX_VERIFIED_VOLUMES = 8
 
 
-class ConfidentialRuntime(HashableModel):
+class VerifiableProgramRuntime(HashableModel):
     """The measured platform: a store message holding the runtime manifest,
     which pins the OVMF, kernel, initrd and dm-verity platform rootfs (plus
     its hash tree) by content hash, and declares the cmdline template, boot
@@ -48,40 +47,6 @@ class ConfidentialRuntime(HashableModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class AttestationProtocol(HashableModel):
-    """One mechanism a client can use to obtain and channel-bind TEE evidence
-    from the running VM, e.g. RA-TLS certificate embedding, IETF attested TLS,
-    or an on-demand evidence endpoint.
-
-    The runtime manifest is the authoritative list of protocols the runtime
-    implements; the message carries this declared copy so clients and CCNs can
-    fail fast without fetching the manifest (checked redundancy, like launch
-    measurements). Protocol identifiers are an open, namespaced string space:
-    known values live in the runtime registry, not in this schema.
-    """
-
-    protocol: str = Field(
-        pattern=ATTESTATION_PROTOCOL_PATTERN,
-        max_length=MAX_ATTESTATION_PROTOCOL_LENGTH,
-        description="Namespaced protocol identifier, e.g. aleph.ra-tls",
-    )
-    version: int = Field(
-        ge=1, description="Protocol version implemented by the runtime"
-    )
-    port: Optional[int] = Field(
-        default=None,
-        ge=1,
-        le=65535,
-        description=(
-            "In-guest port serving this protocol; None means the runtime "
-            "manifest's declared default. Plumbed through the measured "
-            "cmdline; the agent auto-maps a host port for IPv4 clients."
-        ),
-    )
-
-    model_config = ConfigDict(extra="forbid")
-
-
 class VerifiedWorkload(HashableModel):
     """The user's code: a read-only ext4 volume bound into the measured TCB
     via its dm-verity root hash on the kernel cmdline (workload_roothash=)."""
@@ -94,6 +59,31 @@ class VerifiedWorkload(HashableModel):
         pattern=VERITY_ROOTHASH_PATTERN,
         description="dm-verity root hash (sha256, lowercase hex); measured via cmdline",
     )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VerifiedVolume(HashableModel):
+    """An extra read-only data volume bound into the attested TCB, e.g. LLM
+    weights or datasets shared across deployments.
+
+    Volumes are positional: the measured cmdline carries the roothashes in
+    list order (verified_volumes=h1,h2,...), the guest init verity-verifies
+    device i against roothash i and exposes it at a well-known indexed path,
+    and the verity-bound workload contract maps it onward. There is
+    deliberately no mount field: an unmeasured mount mapping would let a
+    malicious host permute volumes.
+    """
+
+    ref: ItemHash = Field(description="Store message of the volume data image")
+    hash_tree: ItemHash = Field(
+        description="Store message of the dm-verity hash tree for the data image"
+    )
+    roothash: str = Field(
+        pattern=VERITY_ROOTHASH_PATTERN,
+        description="dm-verity root hash (sha256, lowercase hex); measured via cmdline",
+    )
+    comment: str = Field(default="", max_length=MAX_RUNTIME_COMMENT_LENGTH)
 
     model_config = ConfigDict(extra="forbid")
 
@@ -126,7 +116,6 @@ class VerifiableProgramEnvironment(HashableModel):
     """Execution environment flags. The hypervisor is always QEMU."""
 
     internet: bool = False
-    aleph_api: bool = False
 
     model_config = ConfigDict(extra="forbid")
 
@@ -140,8 +129,10 @@ class VerifiableProgramContent(BaseExecutableContent):
     (always QEMU). Unlike instances, the rootfs is Aleph-provided and measured;
     the user contribution is the verity-bound workload volume.
 
-    Extra `volumes` are allowed but are OUTSIDE the attested TCB: they are
-    neither measured nor verity-verified.
+    Every input reaching the guest is measured or verity-bound: extra volumes
+    must be verified (VerifiedVolume), and the inherited unmeasured input
+    channels (variables, authorized_keys) are rejected. Workload environment
+    variables belong in the verity-bound workload contract.
     """
 
     payment: Payment = Field(description="Payment details; V-Programs are credit-only")
@@ -151,8 +142,8 @@ class VerifiableProgramContent(BaseExecutableContent):
     environment: VerifiableProgramEnvironment = Field(  # type: ignore[assignment]
         description="Properties of the execution environment"
     )
-    runtime: ConfidentialRuntime = Field(
-        description="The measured platform (runtime bundle)"
+    runtime: VerifiableProgramRuntime = Field(
+        description="The measured platform (runtime manifest)"
     )
     workload: VerifiedWorkload = Field(
         description="The user's verity-bound workload volume"
@@ -160,13 +151,12 @@ class VerifiableProgramContent(BaseExecutableContent):
     verification: TeeVerification = Field(
         description="TEE launch config and expected launch measurements"
     )
-    attestation: List[AttestationProtocol] = Field(
-        min_length=1,
-        max_length=MAX_ATTESTATION_PROTOCOLS,
-        description=(
-            "Attestation protocols the runtime exposes; a declared copy of "
-            "the runtime manifest entries"
-        ),
+    # Only verity-bound volumes are allowed: unverified extra volumes would be
+    # attacker-controllable input inside an attested VM.
+    volumes: List[VerifiedVolume] = Field(  # type: ignore[assignment]
+        default=[],
+        max_length=MAX_VERIFIED_VOLUMES,
+        description="Extra read-only volumes, verity-bound via the measured cmdline",
     )
 
     @property
@@ -180,5 +170,20 @@ class VerifiableProgramContent(BaseExecutableContent):
             raise ValueError(
                 "V-Programs are credit-only: holder-tier and PAYG stream "
                 "payments are not supported"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def check_no_unmeasured_inputs(self) -> Self:
+        if self.variables:
+            raise ValueError(
+                "variables are not supported for V-Programs: environment "
+                "variables would reach the guest unmeasured; ship them in the "
+                "verity-bound workload instead"
+            )
+        if self.authorized_keys:
+            raise ValueError(
+                "authorized_keys are not supported for V-Programs: host key "
+                "injection has no place in an attested VM"
             )
         return self

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -133,6 +133,11 @@ class VerifiableProgramContent(BaseExecutableContent):
     must be verified (VerifiedVolume), and the inherited unmeasured input
     channels (variables, authorized_keys) are rejected. Workload environment
     variables belong in the verity-bound workload contract.
+
+    V-Programs are also immutable: the inherited amendment channel
+    (allow_amend, replaces) is rejected, because an amend would let the
+    measured stack change under a fixed deployment identity. Upgrading is
+    an explicit redeployment: publish a new message, clients re-target it.
     """
 
     payment: Payment = Field(description="Payment details; V-Programs are credit-only")
@@ -170,6 +175,16 @@ class VerifiableProgramContent(BaseExecutableContent):
             raise ValueError(
                 "V-Programs are credit-only: holder-tier and PAYG stream "
                 "payments are not supported"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def check_immutable(self) -> Self:
+        if self.allow_amend or self.replaces is not None:
+            raise ValueError(
+                "V-Programs are immutable: amendment would let the measured "
+                "stack change under a fixed deployment identity; publish a "
+                "new message instead"
             )
         return self
 

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -15,10 +15,14 @@ from ..abstract import HashableModel
 from ..item_hash import ItemHash
 from .abstract import BaseExecutableContent
 from .base import Payment
-from .environment import DEFAULT_SNP_POLICY, LaunchMeasurement, validate_snp_policy
+from .environment import (
+    DEFAULT_SNP_POLICY,
+    MAX_MEASUREMENTS,
+    LaunchMeasurement,
+    validate_snp_policy,
+)
 
 MAX_RUNTIME_COMMENT_LENGTH = 1024
-MAX_MEASUREMENTS = 16
 # sha256 dm-verity root hash, as printed by veritysetup format
 VERITY_ROOTHASH_PATTERN = r"^[0-9a-f]{64}$"
 

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -88,3 +88,56 @@ class VerifiableProgramEnvironment(HashableModel):
     aleph_api: bool = False
 
     model_config = ConfigDict(extra="forbid")
+
+
+class VerifiableProgramContent(BaseExecutableContent):
+    """Message content for scheduling a verifiable program (V-Program): an
+    auto-booting SEV-SNP VM whose full software stack is attestable.
+
+    Unlike classic programs there is no code/entrypoint/triggers model (the
+    workload contract belongs to the runtime bundle) and no hypervisor choice
+    (always QEMU). Unlike instances, the rootfs is Aleph-provided and measured;
+    the user contribution is the verity-bound workload volume.
+
+    Extra `volumes` are allowed but are OUTSIDE the attested TCB: they are
+    neither measured nor verity-verified.
+    """
+
+    payment: Payment = Field(
+        description="Payment details; V-Programs are credit-only"
+    )
+    environment: VerifiableProgramEnvironment = Field(
+        description="Properties of the execution environment"
+    )
+    runtime: ConfidentialRuntime = Field(
+        description="The measured platform (runtime bundle)"
+    )
+    workload: VerifiedWorkload = Field(
+        description="The user's verity-bound workload volume"
+    )
+    verification: TeeVerification = Field(
+        description="TEE launch config and expected launch measurements"
+    )
+    attestation_port: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=65535,
+        description=(
+            "In-guest attestation port; None means the runtime bundle's "
+            "declared default (8443). Plumbed through the measured cmdline."
+        ),
+    )
+
+    @property
+    def is_confidential(self) -> bool:
+        """V-Programs always run in a confidential VM."""
+        return True
+
+    @model_validator(mode="after")
+    def check_payment_is_credit(self) -> Self:
+        if not self.payment.is_credit:
+            raise ValueError(
+                "V-Programs are credit-only: holder-tier and PAYG stream "
+                "payments are not supported"
+            )
+        return self

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -1,0 +1,90 @@
+"""Verifiable programs (V-Programs): auto-booting confidential VMs whose full
+software stack is attestable via SEV-SNP runtime attestation.
+
+Design: aleph-vm docs/plans/2026-07-08-confidential-vm-protocol-design.md
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import ConfigDict, Field, model_validator
+from typing_extensions import Self
+
+from ..abstract import HashableModel
+from ..item_hash import ItemHash
+from .abstract import BaseExecutableContent
+from .base import Payment
+from .environment import DEFAULT_SNP_POLICY, LaunchMeasurement, validate_snp_policy
+
+MAX_RUNTIME_COMMENT_LENGTH = 1024
+MAX_MEASUREMENTS = 16
+# sha256 dm-verity root hash, as printed by veritysetup format
+VERITY_ROOTHASH_PATTERN = r"^[0-9a-f]{64}$"
+
+
+class ConfidentialRuntime(HashableModel):
+    """The measured platform: a store object bundling the manifest, OVMF,
+    kernel, initrd, and the dm-verity platform rootfs with its hash tree.
+
+    There is deliberately no use_latest: the measurements in the message pin
+    exact artifacts, so the reference must be immutable.
+    """
+
+    ref: ItemHash = Field(
+        description="Store message of the measured runtime bundle"
+    )
+    comment: str = Field(default="", max_length=MAX_RUNTIME_COMMENT_LENGTH)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VerifiedWorkload(HashableModel):
+    """The user's code: a read-only ext4 volume bound into the measured TCB
+    via its dm-verity root hash on the kernel cmdline (workload_roothash=)."""
+
+    ref: ItemHash = Field(description="Store message of the workload data image")
+    hash_tree: ItemHash = Field(
+        description="Store message of the dm-verity hash tree for the data image"
+    )
+    roothash: str = Field(
+        pattern=VERITY_ROOTHASH_PATTERN,
+        description="dm-verity root hash (sha256, lowercase hex); measured via cmdline",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TeeVerification(HashableModel):
+    """TEE launch configuration plus supervisor-opaque measurement annotations."""
+
+    backend: Literal["sev_snp"] = Field(
+        description="TEE backend the VM launches with"
+    )
+    policy: int = Field(
+        default=DEFAULT_SNP_POLICY,
+        ge=0,
+        lt=1 << 64,
+        description="SEV-SNP 64-bit guest policy (not SEV bit semantics)",
+    )
+    measurements: List[LaunchMeasurement] = Field(
+        min_length=1,
+        max_length=MAX_MEASUREMENTS,
+        description="Expected launch digests; never sent to the supervisor",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def check_policy(self) -> Self:
+        validate_snp_policy(self.policy)
+        return self
+
+
+class VerifiableProgramEnvironment(HashableModel):
+    """Execution environment flags. The hypervisor is always QEMU."""
+
+    internet: bool = False
+    aleph_api: bool = False
+
+    model_config = ConfigDict(extra="forbid")

--- a/aleph_message/models/execution/vprogram.py
+++ b/aleph_message/models/execution/vprogram.py
@@ -31,9 +31,7 @@ class ConfidentialRuntime(HashableModel):
     exact artifacts, so the reference must be immutable.
     """
 
-    ref: ItemHash = Field(
-        description="Store message of the measured runtime bundle"
-    )
+    ref: ItemHash = Field(description="Store message of the measured runtime bundle")
     comment: str = Field(default="", max_length=MAX_RUNTIME_COMMENT_LENGTH)
 
     model_config = ConfigDict(extra="forbid")
@@ -58,9 +56,7 @@ class VerifiedWorkload(HashableModel):
 class TeeVerification(HashableModel):
     """TEE launch configuration plus supervisor-opaque measurement annotations."""
 
-    backend: Literal["sev_snp"] = Field(
-        description="TEE backend the VM launches with"
-    )
+    backend: Literal["sev_snp"] = Field(description="TEE backend the VM launches with")
     policy: int = Field(
         default=DEFAULT_SNP_POLICY,
         ge=0,
@@ -103,10 +99,11 @@ class VerifiableProgramContent(BaseExecutableContent):
     neither measured nor verity-verified.
     """
 
-    payment: Payment = Field(
-        description="Payment details; V-Programs are credit-only"
-    )
-    environment: VerifiableProgramEnvironment = Field(
+    payment: Payment = Field(description="Payment details; V-Programs are credit-only")
+    # VerifiableProgramEnvironment is deliberately not a member of the
+    # Function/InstanceEnvironment union on BaseExecutableContent: V-Programs
+    # have their own environment shape (see class docstring above).
+    environment: VerifiableProgramEnvironment = Field(  # type: ignore[assignment]
         description="Properties of the execution environment"
     )
     runtime: ConfidentialRuntime = Field(

--- a/aleph_message/tests/messages/vprogram_machine.json
+++ b/aleph_message/tests/messages/vprogram_machine.json
@@ -42,6 +42,13 @@
                 }
             ]
         },
+        "attestation": [
+            {
+                "protocol": "aleph.ra-tls",
+                "version": 1,
+                "port": 8443
+            }
+        ],
         "volumes": []
     }
 }

--- a/aleph_message/tests/messages/vprogram_machine.json
+++ b/aleph_message/tests/messages/vprogram_machine.json
@@ -1,0 +1,47 @@
+{
+    "chain": "ETH",
+    "sender": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+    "type": "V-PROGRAM",
+    "channel": "TEST",
+    "signature": "0x372da8230552b8c3e65c05b31a0ff3a24666d66c575f8e11019f62579bf48c2b7fe2f0bbe907a2a5bf8050989cdaf8a59ff8a1cbcafcdef0656c54279b4aa0c71b",
+    "time": 1719502000.0,
+    "item_type": "inline",
+    "content": {
+        "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "time": 1719502000.0,
+        "allow_amend": false,
+        "payment": {
+            "type": "credit"
+        },
+        "environment": {
+            "internet": true,
+            "aleph_api": false
+        },
+        "resources": {
+            "vcpus": 2,
+            "memory": 2048,
+            "seconds": 30
+        },
+        "runtime": {
+            "ref": "cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe",
+            "comment": "compose-runner snp bundle"
+        },
+        "workload": {
+            "ref": "beefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef",
+            "hash_tree": "feedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeedfeed",
+            "roothash": "cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+        },
+        "verification": {
+            "backend": "sev_snp",
+            "policy": 196608,
+            "measurements": [
+                {
+                    "platform": "sev_snp",
+                    "digest": "abababababababababababababababababababababababababababababababababababababababababababababababab",
+                    "vcpu_type": "EPYC-v4"
+                }
+            ]
+        },
+        "volumes": []
+    }
+}

--- a/aleph_message/tests/messages/vprogram_machine.json
+++ b/aleph_message/tests/messages/vprogram_machine.json
@@ -14,8 +14,7 @@
             "type": "credit"
         },
         "environment": {
-            "internet": true,
-            "aleph_api": false
+            "internet": true
         },
         "resources": {
             "vcpus": 2,
@@ -42,13 +41,13 @@
                 }
             ]
         },
-        "attestation": [
+        "volumes": [
             {
-                "protocol": "aleph.ra-tls",
-                "version": 1,
-                "port": 8443
+                "ref": "dadadadadadadadadadadadadadadadadadadadadadadadadadadadadadadada",
+                "hash_tree": "d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5",
+                "roothash": "efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef",
+                "comment": "model weights"
             }
-        ],
-        "volumes": []
+        ]
     }
 }

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -16,6 +16,7 @@ from aleph_message.models.execution.environment import (
 from aleph_message.models.execution.vprogram import (
     ConfidentialRuntime,
     TeeVerification,
+    VerifiableProgramContent,
     VerifiableProgramEnvironment,
     VerifiedWorkload,
 )
@@ -116,3 +117,73 @@ def test_vprogram_environment_defaults():
     assert env.aleph_api is False
     with pytest.raises(ValidationError):
         VerifiableProgramEnvironment(hypervisor="qemu")  # extra fields forbidden
+
+
+def make_vprogram_content(**overrides) -> dict:
+    """Minimal valid VerifiableProgramContent as a dict."""
+    content = {
+        "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "time": 1719502000.0,
+        "allow_amend": False,
+        "payment": {"type": "credit"},
+        "environment": {"internet": True, "aleph_api": False},
+        "resources": {"vcpus": 2, "memory": 2048, "seconds": 30},
+        "runtime": {"ref": ITEM_HASH, "comment": "compose-runner snp bundle"},
+        "workload": {
+            "ref": ITEM_HASH,
+            "hash_tree": ITEM_HASH,
+            "roothash": "cd" * 32,
+        },
+        "verification": {
+            "backend": "sev_snp",
+            "policy": 0x30000,
+            "measurements": [
+                {"platform": "sev_snp", "digest": SNP_DIGEST, "vcpu_type": "EPYC-v4"}
+            ],
+        },
+    }
+    content.update(overrides)
+    return content
+
+
+def test_vprogram_content_valid():
+    content = VerifiableProgramContent.model_validate(make_vprogram_content())
+    assert content.payment.is_credit
+    assert content.is_confidential is True
+    assert content.attestation_port is None  # bundle default (8443)
+    assert content.verification.measurements[0].vcpu_type == "EPYC-v4"
+
+
+def test_vprogram_content_is_credit_only():
+    for payment_type in ("hold", "superfluid"):
+        with pytest.raises(ValidationError, match="credit"):
+            VerifiableProgramContent.model_validate(
+                make_vprogram_content(payment={"type": payment_type})
+            )
+
+
+def test_vprogram_content_payment_required():
+    content = make_vprogram_content()
+    del content["payment"]
+    with pytest.raises(ValidationError):
+        VerifiableProgramContent.model_validate(content)
+
+
+def test_vprogram_content_attestation_port_bounds():
+    ok = VerifiableProgramContent.model_validate(
+        make_vprogram_content(attestation_port=8443)
+    )
+    assert ok.attestation_port == 8443
+    for bad_port in (0, 65536):
+        with pytest.raises(ValidationError):
+            VerifiableProgramContent.model_validate(
+                make_vprogram_content(attestation_port=bad_port)
+            )
+
+
+def test_vprogram_content_node_hash_is_optional():
+    # dispatch is scheduler-driven; node_hash is only an optional placement pin
+    content = VerifiableProgramContent.model_validate(
+        make_vprogram_content(requirements={"node": {"node_hash": ITEM_HASH}})
+    )
+    assert content.requirements.node.node_hash == ITEM_HASH

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -3,9 +3,18 @@
 Design: aleph-vm docs/plans/2026-07-08-confidential-vm-protocol-design.md
 """
 
+import json
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
+from aleph_message.models import (
+    VerifiableProgramMessage,
+    add_item_content_and_hash,
+    create_message_from_file,
+    parse_message,
+)
 from aleph_message.models.base import MessageType
 from aleph_message.models.execution.environment import (
     DEFAULT_SNP_POLICY,
@@ -187,3 +196,22 @@ def test_vprogram_content_node_hash_is_optional():
         make_vprogram_content(requirements={"node": {"node_hash": ITEM_HASH}})
     )
     assert content.requirements.node.node_hash == ITEM_HASH
+
+
+def test_vprogram_message_machine():
+    path = Path(__file__).parent / "messages/vprogram_machine.json"
+    message = create_message_from_file(path, factory=VerifiableProgramMessage)
+    assert isinstance(message, VerifiableProgramMessage)
+    assert message.type == "V-PROGRAM"
+    assert message.content.is_confidential
+    assert hash(message.content)
+    # the factory-less path must dispatch to the same class
+    assert isinstance(create_message_from_file(path), VerifiableProgramMessage)
+
+
+def test_parse_message_dispatches_v_program():
+    path = Path(__file__).parent / "messages/vprogram_machine.json"
+    message_dict = json.loads(path.read_text())
+    add_item_content_and_hash(message_dict, inplace=True)
+    message = parse_message(message_dict)
+    assert isinstance(message, VerifiableProgramMessage)

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -25,6 +25,7 @@ from aleph_message.models.execution.environment import (
 )
 from aleph_message.models.execution.instance import InstanceContent
 from aleph_message.models.execution.vprogram import (
+    AttestationProtocol,
     ConfidentialRuntime,
     TeeVerification,
     VerifiableProgramContent,
@@ -171,6 +172,7 @@ def make_vprogram_content(**overrides) -> dict:
                 {"platform": "sev_snp", "digest": SNP_DIGEST, "vcpu_type": "EPYC-v4"}
             ],
         },
+        "attestation": [{"protocol": "aleph.ra-tls", "version": 1, "port": 8443}],
     }
     content.update(overrides)
     return content
@@ -180,7 +182,9 @@ def test_vprogram_content_valid():
     content = VerifiableProgramContent.model_validate(make_vprogram_content())
     assert content.payment.is_credit
     assert content.is_confidential is True
-    assert content.attestation_port is None  # bundle default (8443)
+    assert content.attestation[0].protocol == "aleph.ra-tls"
+    assert content.attestation[0].version == 1
+    assert content.attestation[0].port == 8443
     assert content.verification.measurements[0].vcpu_type == "EPYC-v4"
 
 
@@ -201,16 +205,55 @@ def test_vprogram_content_payment_required():
         VerifiableProgramContent.model_validate(make_vprogram_content(payment=None))
 
 
-def test_vprogram_content_attestation_port_bounds():
-    ok = VerifiableProgramContent.model_validate(
-        make_vprogram_content(attestation_port=8443)
-    )
-    assert ok.attestation_port == 8443
+def test_attestation_protocol_valid():
+    p = AttestationProtocol(protocol="aleph.ra-tls", version=1, port=8443)
+    assert p.protocol == "aleph.ra-tls"
+    # port is optional: None means the runtime manifest's declared default
+    assert AttestationProtocol(protocol="ietf.tls-attest", version=2).port is None
+
+
+def test_attestation_protocol_rejects_bad_identifiers():
+    for bad in (
+        "ra-tls",  # no namespace separator
+        "RA-TLS.v1",  # uppercase
+        "aleph.",  # empty segment
+        ".ra-tls",  # empty namespace
+        "aleph .ra-tls",  # whitespace
+        "a" * 63 + ".b" * 2,  # over the length cap
+    ):
+        with pytest.raises(ValidationError):
+            AttestationProtocol(protocol=bad, version=1)
+
+
+def test_attestation_protocol_version_and_port_bounds():
+    with pytest.raises(ValidationError):
+        AttestationProtocol(protocol="aleph.ra-tls", version=0)
     for bad_port in (0, 65536):
         with pytest.raises(ValidationError):
-            VerifiableProgramContent.model_validate(
-                make_vprogram_content(attestation_port=bad_port)
-            )
+            AttestationProtocol(protocol="aleph.ra-tls", version=1, port=bad_port)
+
+
+def test_attestation_protocol_forbids_extra_fields():
+    with pytest.raises(ValidationError):
+        AttestationProtocol(protocol="aleph.ra-tls", version=1, oid="1.2.3")
+
+
+def test_vprogram_content_requires_attestation():
+    content = make_vprogram_content()
+    del content["attestation"]
+    with pytest.raises(ValidationError, match="attestation"):
+        VerifiableProgramContent.model_validate(content)
+    # the declared list must not be empty and is capped
+    with pytest.raises(ValidationError):
+        VerifiableProgramContent.model_validate(make_vprogram_content(attestation=[]))
+    too_many = [
+        {"protocol": f"aleph.proto-{i}", "version": 1}
+        for i in range(9)  # MAX_ATTESTATION_PROTOCOLS + 1
+    ]
+    with pytest.raises(ValidationError):
+        VerifiableProgramContent.model_validate(
+            make_vprogram_content(attestation=too_many)
+        )
 
 
 def test_vprogram_content_node_hash_is_optional():

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -25,11 +25,11 @@ from aleph_message.models.execution.environment import (
 )
 from aleph_message.models.execution.instance import InstanceContent
 from aleph_message.models.execution.vprogram import (
-    AttestationProtocol,
-    ConfidentialRuntime,
     TeeVerification,
     VerifiableProgramContent,
     VerifiableProgramEnvironment,
+    VerifiableProgramRuntime,
+    VerifiedVolume,
     VerifiedWorkload,
 )
 
@@ -97,11 +97,11 @@ def test_validate_snp_policy_bounds():
 ITEM_HASH = "cafe" * 16  # 64 hex chars, valid storage ItemHash
 
 
-def test_confidential_runtime():
-    r = ConfidentialRuntime(ref=ITEM_HASH, comment="compose-runner snp bundle")
+def test_verifiable_program_runtime():
+    r = VerifiableProgramRuntime(ref=ITEM_HASH, comment="compose-runner snp bundle")
     assert r.ref == ITEM_HASH
     # no use_latest field exists: measurements pin exact artifacts
-    assert "use_latest" not in ConfidentialRuntime.model_fields
+    assert "use_latest" not in VerifiableProgramRuntime.model_fields
 
 
 def test_verified_workload_roothash_validation():
@@ -145,9 +145,10 @@ def test_tee_verification_rejects_negative_policy():
 def test_vprogram_environment_defaults():
     env = VerifiableProgramEnvironment()
     assert env.internet is False
-    assert env.aleph_api is False
     with pytest.raises(ValidationError):
         VerifiableProgramEnvironment(hypervisor="qemu")  # extra fields forbidden
+    with pytest.raises(ValidationError):
+        VerifiableProgramEnvironment(aleph_api=True)  # dropped legacy program flag
 
 
 def make_vprogram_content(**overrides) -> dict:
@@ -157,7 +158,7 @@ def make_vprogram_content(**overrides) -> dict:
         "time": 1719502000.0,
         "allow_amend": False,
         "payment": {"type": "credit"},
-        "environment": {"internet": True, "aleph_api": False},
+        "environment": {"internet": True},
         "resources": {"vcpus": 2, "memory": 2048, "seconds": 30},
         "runtime": {"ref": ITEM_HASH, "comment": "compose-runner snp bundle"},
         "workload": {
@@ -172,7 +173,6 @@ def make_vprogram_content(**overrides) -> dict:
                 {"platform": "sev_snp", "digest": SNP_DIGEST, "vcpu_type": "EPYC-v4"}
             ],
         },
-        "attestation": [{"protocol": "aleph.ra-tls", "version": 1, "port": 8443}],
     }
     content.update(overrides)
     return content
@@ -182,9 +182,7 @@ def test_vprogram_content_valid():
     content = VerifiableProgramContent.model_validate(make_vprogram_content())
     assert content.payment.is_credit
     assert content.is_confidential is True
-    assert content.attestation[0].protocol == "aleph.ra-tls"
-    assert content.attestation[0].version == 1
-    assert content.attestation[0].port == 8443
+    assert content.volumes == []
     assert content.verification.measurements[0].vcpu_type == "EPYC-v4"
 
 
@@ -205,54 +203,63 @@ def test_vprogram_content_payment_required():
         VerifiableProgramContent.model_validate(make_vprogram_content(payment=None))
 
 
-def test_attestation_protocol_valid():
-    p = AttestationProtocol(protocol="aleph.ra-tls", version=1, port=8443)
-    assert p.protocol == "aleph.ra-tls"
-    # port is optional: None means the runtime manifest's declared default
-    assert AttestationProtocol(protocol="ietf.tls-attest", version=2).port is None
+def test_verified_volume():
+    v = VerifiedVolume(
+        ref=ITEM_HASH, hash_tree=ITEM_HASH, roothash="ab" * 32, comment="llm weights"
+    )
+    assert v.roothash == "ab" * 32
+    # no mount field: binding is positional via the measured cmdline, and an
+    # unmeasured mount mapping would let a malicious host permute volumes
+    assert "mount" not in VerifiedVolume.model_fields
+    with pytest.raises(ValidationError):
+        VerifiedVolume(ref=ITEM_HASH, hash_tree=ITEM_HASH, roothash="ab" * 31)
+    with pytest.raises(ValidationError):
+        VerifiedVolume(
+            ref=ITEM_HASH, hash_tree=ITEM_HASH, roothash="ab" * 32, mount="/data"
+        )
 
 
-def test_attestation_protocol_rejects_bad_identifiers():
-    for bad in (
-        "ra-tls",  # no namespace separator
-        "RA-TLS.v1",  # uppercase
-        "aleph.",  # empty segment
-        ".ra-tls",  # empty namespace
-        "aleph .ra-tls",  # whitespace
-        "a" * 63 + ".b" * 2,  # over the length cap
+def test_vprogram_content_accepts_verified_volumes():
+    volume = {"ref": ITEM_HASH, "hash_tree": ITEM_HASH, "roothash": "ab" * 32}
+    content = VerifiableProgramContent.model_validate(
+        make_vprogram_content(volumes=[volume])
+    )
+    assert content.volumes[0].roothash == "ab" * 32
+
+
+def test_vprogram_content_rejects_unverified_volumes():
+    # classic machine volumes are unmeasured input inside an attested VM
+    for bad_volume in (
+        {"ephemeral": True, "mount": "/var/cache", "size_mib": 5},
+        {"ref": ITEM_HASH, "mount": "/opt/venv", "use_latest": False},
+        {"persistence": "host", "name": "scratch", "mount": "/var/raw", "size_mib": 1},
     ):
         with pytest.raises(ValidationError):
-            AttestationProtocol(protocol=bad, version=1)
+            VerifiableProgramContent.model_validate(
+                make_vprogram_content(volumes=[bad_volume])
+            )
 
 
-def test_attestation_protocol_version_and_port_bounds():
-    with pytest.raises(ValidationError):
-        AttestationProtocol(protocol="aleph.ra-tls", version=0)
-    for bad_port in (0, 65536):
-        with pytest.raises(ValidationError):
-            AttestationProtocol(protocol="aleph.ra-tls", version=1, port=bad_port)
-
-
-def test_attestation_protocol_forbids_extra_fields():
-    with pytest.raises(ValidationError):
-        AttestationProtocol(protocol="aleph.ra-tls", version=1, oid="1.2.3")
-
-
-def test_vprogram_content_requires_attestation():
-    content = make_vprogram_content()
-    del content["attestation"]
-    with pytest.raises(ValidationError, match="attestation"):
-        VerifiableProgramContent.model_validate(content)
-    # the declared list must not be empty and is capped
-    with pytest.raises(ValidationError):
-        VerifiableProgramContent.model_validate(make_vprogram_content(attestation=[]))
-    too_many = [
-        {"protocol": f"aleph.proto-{i}", "version": 1}
-        for i in range(9)  # MAX_ATTESTATION_PROTOCOLS + 1
-    ]
+def test_vprogram_content_caps_verified_volumes():
+    volume = {"ref": ITEM_HASH, "hash_tree": ITEM_HASH, "roothash": "ab" * 32}
     with pytest.raises(ValidationError):
         VerifiableProgramContent.model_validate(
-            make_vprogram_content(attestation=too_many)
+            make_vprogram_content(volumes=[volume] * 9)  # MAX_VERIFIED_VOLUMES + 1
+        )
+
+
+def test_vprogram_content_rejects_unmeasured_inputs():
+    with pytest.raises(ValidationError, match="variables"):
+        VerifiableProgramContent.model_validate(
+            make_vprogram_content(variables={"VM_CUSTOM_VARIABLE": "SOMETHING"})
+        )
+    key = (
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGULT6A41Msmw2KEu0R9MvUjhuWNAsbdeZ0DOwYbt4Qt"
+        " user@example"
+    )
+    with pytest.raises(ValidationError, match="authorized_keys"):
+        VerifiableProgramContent.model_validate(
+            make_vprogram_content(authorized_keys=[key])
         )
 
 

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -3,9 +3,63 @@
 Design: aleph-vm docs/plans/2026-07-08-confidential-vm-protocol-design.md
 """
 
+import pytest
+from pydantic import ValidationError
+
 from aleph_message.models.base import MessageType
+from aleph_message.models.execution.environment import (
+    DEFAULT_SNP_POLICY,
+    LaunchMeasurement,
+    TeePlatform,
+    validate_snp_policy,
+)
+
+SNP_DIGEST = "ab" * 48  # 96 hex chars, 48 bytes
+SHA256_HEX = "cd" * 32  # 64 hex chars
 
 
 def test_message_type_v_program():
     assert MessageType.v_program.value == "V-PROGRAM"
     assert MessageType("V-PROGRAM") is MessageType.v_program
+
+
+def test_launch_measurement_valid():
+    m = LaunchMeasurement(
+        platform=TeePlatform.sev_snp, digest=SNP_DIGEST, vcpu_type="EPYC-v4"
+    )
+    assert m.platform is TeePlatform.sev_snp
+    assert m.vcpu_type == "EPYC-v4"
+    # vcpu_type is optional: absent for igvm-recipe bundles
+    assert LaunchMeasurement(platform="sev_snp", digest=SNP_DIGEST).vcpu_type is None
+
+
+def test_launch_measurement_rejects_bad_digests():
+    # wrong length for sev_snp (sha256-sized digest)
+    with pytest.raises(ValidationError):
+        LaunchMeasurement(platform="sev_snp", digest=SHA256_HEX)
+    # non-hex content
+    with pytest.raises(ValidationError):
+        LaunchMeasurement(platform="sev_snp", digest="zz" * 48)
+    # uppercase hex is rejected (canonical form is lowercase)
+    with pytest.raises(ValidationError):
+        LaunchMeasurement(platform="sev_snp", digest="AB" * 48)
+
+
+def test_launch_measurement_rejects_unknown_platform():
+    # unknown platforms are schema-invalid until a protocol upgrade adds them
+    with pytest.raises(ValidationError):
+        LaunchMeasurement(platform="tdx", digest=SNP_DIGEST)
+
+
+def test_launch_measurement_forbids_extra_fields():
+    with pytest.raises(ValidationError):
+        LaunchMeasurement(platform="sev_snp", digest=SNP_DIGEST, extra_field=1)
+
+
+def test_validate_snp_policy():
+    validate_snp_policy(DEFAULT_SNP_POLICY)  # 0x30000: bits 16+17
+    validate_snp_policy(1 << 17)
+    with pytest.raises(ValueError):
+        validate_snp_policy(0x1)  # the AMD SEV default lacks bit 17
+    with pytest.raises(ValueError):
+        validate_snp_policy(0x10000)  # SMT bit alone, no bit 17

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -263,6 +263,17 @@ def test_vprogram_content_rejects_unmeasured_inputs():
         )
 
 
+def test_vprogram_content_rejects_amendment():
+    # An amend would let the measured stack change under a fixed deployment
+    # identity; upgrades are explicit redeployments (new message, new hash).
+    with pytest.raises(ValidationError, match="immutable"):
+        VerifiableProgramContent.model_validate(make_vprogram_content(allow_amend=True))
+    with pytest.raises(ValidationError, match="immutable"):
+        VerifiableProgramContent.model_validate(
+            make_vprogram_content(replaces="cafe" * 16)
+        )
+
+
 def test_vprogram_content_node_hash_is_optional():
     # dispatch is scheduler-driven; node_hash is only an optional placement pin
     content = VerifiableProgramContent.model_validate(

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -13,6 +13,12 @@ from aleph_message.models.execution.environment import (
     TeePlatform,
     validate_snp_policy,
 )
+from aleph_message.models.execution.vprogram import (
+    ConfidentialRuntime,
+    TeeVerification,
+    VerifiableProgramEnvironment,
+    VerifiedWorkload,
+)
 
 SNP_DIGEST = "ab" * 48  # 96 hex chars, 48 bytes
 SHA256_HEX = "cd" * 32  # 64 hex chars
@@ -64,13 +70,6 @@ def test_validate_snp_policy():
     with pytest.raises(ValueError):
         validate_snp_policy(0x10000)  # SMT bit alone, no bit 17
 
-
-from aleph_message.models.execution.vprogram import (
-    ConfidentialRuntime,
-    TeeVerification,
-    VerifiableProgramEnvironment,
-    VerifiedWorkload,
-)
 
 ITEM_HASH = "cafe" * 16  # 64 hex chars, valid storage ItemHash
 

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -20,6 +20,7 @@ from aleph_message.models.execution.environment import (
     DEFAULT_SNP_POLICY,
     LaunchMeasurement,
     TeePlatform,
+    TrustedExecutionEnvironment,
     validate_snp_policy,
 )
 from aleph_message.models.execution.vprogram import (
@@ -215,3 +216,67 @@ def test_parse_message_dispatches_v_program():
     add_item_content_and_hash(message_dict, inplace=True)
     message = parse_message(message_dict)
     assert isinstance(message, VerifiableProgramMessage)
+
+
+def make_snp_tee(**overrides) -> dict:
+    tee = {
+        "mode": "sev_snp",
+        "policy": 0x30000,
+        "runtime": ITEM_HASH,
+        "measurements": [{"platform": "sev_snp", "digest": SNP_DIGEST}],
+    }
+    tee.update(overrides)
+    return tee
+
+
+def test_trusted_execution_legacy_sev_unchanged():
+    # the exact shape of the existing confidential fixture must keep parsing
+    tee = TrustedExecutionEnvironment.model_validate(
+        {"policy": 1, "firmware": "e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317"}
+    )
+    assert tee.mode is None  # None means legacy SEV
+    assert tee.is_snp is False
+    # dump stability: no new keys appear on legacy content
+    dump = tee.model_dump(exclude_none=True)
+    assert set(dump) == {"policy", "firmware"}
+
+
+def test_trusted_execution_snp_valid():
+    tee = TrustedExecutionEnvironment.model_validate(make_snp_tee())
+    assert tee.is_snp is True
+    assert tee.runtime == ITEM_HASH
+    assert tee.measurements[0].platform is TeePlatform.sev_snp
+
+
+def test_trusted_execution_snp_requires_fields():
+    for missing in ("runtime", "measurements"):
+        tee = make_snp_tee()
+        del tee[missing]
+        with pytest.raises(ValidationError, match=missing):
+            TrustedExecutionEnvironment.model_validate(tee)
+
+
+def test_trusted_execution_snp_forbids_firmware():
+    with pytest.raises(ValidationError, match="firmware"):
+        TrustedExecutionEnvironment.model_validate(
+            make_snp_tee(firmware="e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317")
+        )
+
+
+def test_trusted_execution_snp_policy_bit17():
+    # the implicit SEV default (0x1) is not a valid SNP policy: an explicit,
+    # SNP-valid policy is effectively required in sev_snp mode
+    tee = make_snp_tee()
+    del tee["policy"]
+    with pytest.raises(ValidationError, match="bit 17"):
+        TrustedExecutionEnvironment.model_validate(tee)
+
+
+def test_trusted_execution_sev_forbids_snp_fields():
+    for extra in (
+        {"runtime": ITEM_HASH},
+        {"measurements": [{"platform": "sev_snp", "digest": SNP_DIGEST}]},
+        {"attestation_port": 8443},
+    ):
+        with pytest.raises(ValidationError, match="sev_snp"):
+            TrustedExecutionEnvironment.model_validate({"policy": 1, **extra})

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -23,6 +23,7 @@ from aleph_message.models.execution.environment import (
     TrustedExecutionEnvironment,
     validate_snp_policy,
 )
+from aleph_message.models.execution.instance import InstanceContent
 from aleph_message.models.execution.vprogram import (
     ConfidentialRuntime,
     TeeVerification,
@@ -280,3 +281,51 @@ def test_trusted_execution_sev_forbids_snp_fields():
     ):
         with pytest.raises(ValidationError, match="sev_snp"):
             TrustedExecutionEnvironment.model_validate({"policy": 1, **extra})
+
+
+def make_snp_instance_content(payment: dict) -> dict:
+    return {
+        "address": "0x9319Ad3B7A8E0eE24f2E639c40D8eD124C5520Ba",
+        "time": 1719502000.0,
+        "allow_amend": False,
+        "payment": payment,
+        "environment": {
+            "internet": True,
+            "aleph_api": False,
+            "hypervisor": "qemu",
+            "trusted_execution": make_snp_tee(),
+        },
+        "resources": {"vcpus": 2, "memory": 2048, "seconds": 30},
+        "rootfs": {
+            "parent": {"ref": ITEM_HASH, "use_latest": False},
+            "persistence": "host",
+            "size_mib": 4096,
+        },
+    }
+
+
+def test_snp_instance_requires_credit_payment():
+    content = InstanceContent.model_validate(
+        make_snp_instance_content(payment={"type": "credit"})
+    )
+    assert content.environment.trusted_execution.is_snp
+
+    with pytest.raises(ValidationError, match="credit"):
+        InstanceContent.model_validate(
+            make_snp_instance_content(payment={"type": "hold"})
+        )
+    with pytest.raises(ValidationError, match="credit"):
+        InstanceContent.model_validate(
+            make_snp_instance_content(payment={"type": "superfluid", "chain": "AVAX"})
+        )
+
+
+def test_legacy_sev_instance_payment_unrestricted():
+    # legacy SEV coco instances keep working with hold payments
+    content_dict = make_snp_instance_content(payment={"type": "hold"})
+    content_dict["environment"]["trusted_execution"] = {
+        "policy": 1,
+        "firmware": ITEM_HASH,
+    }
+    content = InstanceContent.model_validate(content_dict)
+    assert content.environment.trusted_execution.is_snp is False

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -233,7 +233,10 @@ def make_snp_tee(**overrides) -> dict:
 def test_trusted_execution_legacy_sev_unchanged():
     # the exact shape of the existing confidential fixture must keep parsing
     tee = TrustedExecutionEnvironment.model_validate(
-        {"policy": 1, "firmware": "e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317"}
+        {
+            "policy": 1,
+            "firmware": "e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317",
+        }
     )
     assert tee.mode is None  # None means legacy SEV
     assert tee.is_snp is False
@@ -260,7 +263,9 @@ def test_trusted_execution_snp_requires_fields():
 def test_trusted_execution_snp_forbids_firmware():
     with pytest.raises(ValidationError, match="firmware"):
         TrustedExecutionEnvironment.model_validate(
-            make_snp_tee(firmware="e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317")
+            make_snp_tee(
+                firmware="e258d248fda94c63753607f7c4494ee0fcbe92f1a76bfdac795c9d84101eb317"
+            )
         )
 
 

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -1,0 +1,11 @@
+"""Tests for the V-PROGRAM message type and the SEV-SNP TEE extension.
+
+Design: aleph-vm docs/plans/2026-07-08-confidential-vm-protocol-design.md
+"""
+
+from aleph_message.models.base import MessageType
+
+
+def test_message_type_v_program():
+    assert MessageType.v_program.value == "V-PROGRAM"
+    assert MessageType("V-PROGRAM") is MessageType.v_program

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -83,6 +83,16 @@ def test_validate_snp_policy():
         validate_snp_policy(0x10000)  # SMT bit alone, no bit 17
 
 
+def test_validate_snp_policy_bounds():
+    # negative values must not slip past the bit-17 check via Python's
+    # arbitrary-precision integer semantics (bit 17 of -1 is "set")
+    with pytest.raises(ValueError):
+        validate_snp_policy(-1)
+    # must fit in an unsigned 64-bit integer
+    with pytest.raises(ValueError):
+        validate_snp_policy((1 << 64) | (1 << 17))
+
+
 ITEM_HASH = "cafe" * 16  # 64 hex chars, valid storage ItemHash
 
 
@@ -120,6 +130,15 @@ def test_tee_verification_defaults_and_policy():
 def test_tee_verification_requires_measurements():
     with pytest.raises(ValidationError):
         TeeVerification(backend="sev_snp", measurements=[])
+
+
+def test_tee_verification_rejects_negative_policy():
+    with pytest.raises(ValidationError):
+        TeeVerification(
+            backend="sev_snp",
+            policy=-1,
+            measurements=[LaunchMeasurement(platform="sev_snp", digest=SNP_DIGEST)],
+        )
 
 
 def test_vprogram_environment_defaults():
@@ -178,6 +197,8 @@ def test_vprogram_content_payment_required():
     del content["payment"]
     with pytest.raises(ValidationError):
         VerifiableProgramContent.model_validate(content)
+    with pytest.raises(ValidationError):
+        VerifiableProgramContent.model_validate(make_vprogram_content(payment=None))
 
 
 def test_vprogram_content_attestation_port_bounds():
@@ -276,6 +297,11 @@ def test_trusted_execution_snp_policy_bit17():
     del tee["policy"]
     with pytest.raises(ValidationError, match="bit 17"):
         TrustedExecutionEnvironment.model_validate(tee)
+
+
+def test_trusted_execution_snp_rejects_negative_policy():
+    with pytest.raises(ValidationError):
+        TrustedExecutionEnvironment.model_validate(make_snp_tee(policy=-1))
 
 
 def test_trusted_execution_sev_forbids_snp_fields():

--- a/aleph_message/tests/test_vprogram.py
+++ b/aleph_message/tests/test_vprogram.py
@@ -63,3 +63,57 @@ def test_validate_snp_policy():
         validate_snp_policy(0x1)  # the AMD SEV default lacks bit 17
     with pytest.raises(ValueError):
         validate_snp_policy(0x10000)  # SMT bit alone, no bit 17
+
+
+from aleph_message.models.execution.vprogram import (
+    ConfidentialRuntime,
+    TeeVerification,
+    VerifiableProgramEnvironment,
+    VerifiedWorkload,
+)
+
+ITEM_HASH = "cafe" * 16  # 64 hex chars, valid storage ItemHash
+
+
+def test_confidential_runtime():
+    r = ConfidentialRuntime(ref=ITEM_HASH, comment="compose-runner snp bundle")
+    assert r.ref == ITEM_HASH
+    # no use_latest field exists: measurements pin exact artifacts
+    assert "use_latest" not in ConfidentialRuntime.model_fields
+
+
+def test_verified_workload_roothash_validation():
+    w = VerifiedWorkload(ref=ITEM_HASH, hash_tree=ITEM_HASH, roothash="cd" * 32)
+    assert w.roothash == "cd" * 32
+    with pytest.raises(ValidationError):
+        VerifiedWorkload(ref=ITEM_HASH, hash_tree=ITEM_HASH, roothash="cd" * 31)
+    with pytest.raises(ValidationError):
+        VerifiedWorkload(ref=ITEM_HASH, hash_tree=ITEM_HASH, roothash="ZZ" * 32)
+
+
+def test_tee_verification_defaults_and_policy():
+    v = TeeVerification(
+        backend="sev_snp",
+        measurements=[LaunchMeasurement(platform="sev_snp", digest=SNP_DIGEST)],
+    )
+    assert v.policy == 0x30000
+    with pytest.raises(ValidationError):
+        # SEV-style policy value is invalid for SNP (bit 17 unset)
+        TeeVerification(
+            backend="sev_snp",
+            policy=0x1,
+            measurements=[LaunchMeasurement(platform="sev_snp", digest=SNP_DIGEST)],
+        )
+
+
+def test_tee_verification_requires_measurements():
+    with pytest.raises(ValidationError):
+        TeeVerification(backend="sev_snp", measurements=[])
+
+
+def test_vprogram_environment_defaults():
+    env = VerifiableProgramEnvironment()
+    assert env.internet is False
+    assert env.aleph_api is False
+    with pytest.raises(ValidationError):
+        VerifiableProgramEnvironment(hypervisor="qemu")  # extra fields forbidden


### PR DESCRIPTION
Adds the protocol schema for SEV-SNP confidential VMs, per the design in
aleph-vm `docs/plans/2026-07-08-confidential-vm-protocol-design.md`:

- New **V-PROGRAM** message type (`VerifiableProgramMessage` /
  `VerifiableProgramContent`): measured runtime bundle ref, verity-bound
  workload volume (data image + hash tree + roothash), platform-tagged
  launch-measurement annotations (`LaunchMeasurement`), credit-only payment,
  optional `attestation_port`.
- `TrustedExecutionEnvironment` gains an optional **`sev_snp` mode** (runtime
  bundle ref, measurements, attestation_port) alongside the untouched legacy
  SEV flow; SEV-SNP instances are credit-only.

Deviations from the design doc, for wire stability:

- `mode` is `Optional` with `None` = legacy SEV, instead of defaulting to
  `"sev"`, so legacy content dumps are unchanged (verified byte-identical
  `model_dump(exclude_none=True)` for all pre-existing fixtures).
- `policy` keeps its `int` type and SEV default; SNP mode enforces an
  explicit SNP-valid policy via `validate_snp_policy` (reserved bit 17 plus
  unsigned-64-bit range, shared by both models).

Implementation notes:

- `validate_snp_policy` coerces via `int()`: on Python 3.14 a plain
  `(int, Enum)` member (the field default `AMDSEVPolicy.NO_DBG`) no longer
  supports `format(..., "#x")`.
- One `# type: ignore[assignment]` in `vprogram.py` on the `environment`
  override: `VerifiableProgramEnvironment` deliberately does not join the
  base union (that would wrongly allow it on Instance/Program); pydantic v2
  supports the field re-declaration at runtime.
- New tests live in `aleph_message/tests/test_vprogram.py` (29 tests) plus a
  fixture message exercising the inline `check_content` dump-equality path.

## Update (2026-07-09): review feedback wave

Attestation-as-a-protocol discussion plus schema tightening (commits `6ab1597`, `08898ec`, net effect):

- **`ConfidentialRuntime` renamed to `VerifiableProgramRuntime`**: the defining property is verifiability, not confidentiality. `runtime.ref` now points at the **runtime manifest**, a small store object pinning the OVMF/kernel/initrd/verity-rootfs artifacts by content hash and declaring the cmdline template, boot format, and attestation protocols (protocol identity is modeled as namespaced, versioned descriptors **in the manifest**, not in the message: a pure copy of immutable content-addressed data would be denormalization without the checked-redundancy payoff that measurements have). The former `attestation_port` is gone too: the port is a runtime property (the current init hardwires it); a measured per-deployment override can be added schema-additively if a use case appears.
- **`aleph_api` dropped from `VerifiableProgramEnvironment`**: legacy program-runtime concept; a host-injected API channel has no place inside a measured TCB.
- **`volumes` are now `VerifiedVolume` only** (same `ref`/`hash_tree`/`roothash` triple as the workload, max 8): unverified extra volumes would be attacker-controllable input inside an attested VM (content substitution, malicious-filesystem kernel attack surface). Binding is positional through the measured cmdline (`verified_volumes=h1,h2,...`); there is deliberately no `mount` field, since an unmeasured mount mapping would allow volume permutation. Use case: large shared read-only data (LLM weights) without baking it into every workload image.
- **`variables` and `authorized_keys` rejected** on V-Programs: both are unmeasured host-to-guest input channels. Workload env belongs in the verity-bound workload contract; host SSH-key injection has no place in an attested VM.
- Canonical cross-SDK fixture: item_hash is now `4c319b6bdf98f1e90f2bf8c69da175679fa21ca27d4547bbfa32f77dd3b49fe6` (environment/volumes shapes changed; the fixture now exercises a verified volume). aleph-rs #297 and pyaleph #1220 fixtures must be regenerated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
